### PR TITLE
Use a non-quadratic collection frequency.

### DIFF
--- a/gc/benches/alloc_in_a_loop.rs
+++ b/gc/benches/alloc_in_a_loop.rs
@@ -1,0 +1,32 @@
+#![feature(test)]
+
+extern crate test;
+extern crate gc;
+
+const THING: u64 = 0;
+
+fn discard(b: &mut test::Bencher, n: usize) {
+    b.iter(|| {
+        gc::force_collect();
+        for _ in 0..n {
+            test::black_box(gc::Gc::new(THING));
+        }
+    })
+}
+fn keep(b: &mut test::Bencher, n: usize) {
+    b.iter(|| {
+        gc::force_collect();
+        (0..n).map(|_| {
+            gc::Gc::new(THING)
+        }).collect::<Vec<_>>()
+    })
+}
+
+#[bench]
+fn discard_100(b: &mut test::Bencher) { discard(b, 100) }
+#[bench]
+fn keep_100(b: &mut test::Bencher) { keep(b, 100) }
+#[bench]
+fn discard_10000(b: &mut test::Bencher) { discard(b, 10_000) }
+#[bench]
+fn keep_10000(b: &mut test::Bencher) { keep(b, 10_000) }

--- a/gc/src/gc.rs
+++ b/gc/src/gc.rs
@@ -3,11 +3,17 @@ use std::mem;
 use std::cell::{Cell, RefCell};
 use trace::Trace;
 
-// XXX Obviously not 100 bytes GC threshold - choose a number
-const GC_THRESHOLD: usize = 100;
+const INITIAL_THRESHOLD: usize = 100;
+
+// after collection we want the the ratio of used/total to be no
+// greater than this (the threshold grows exponentially, to avoid
+// quadratic behavior when the heap is growing linearly with the
+// number of `new` calls):
+const USED_SPACE_RATIO: f64 = 0.7;
 
 struct GcState {
     bytes_allocated: usize,
+    threshold: usize,
     boxes_start: Option<Box<GcBoxTrait + 'static>>,
     boxes_end: *mut Option<Box<GcBoxTrait + 'static>>,
 }
@@ -19,6 +25,7 @@ thread_local!(static GC_SWEEPING: Cell<bool> = Cell::new(false));
 /// The garbage collector's internal state.
 thread_local!(static GC_STATE: RefCell<GcState> = RefCell::new(GcState {
     bytes_allocated: 0,
+    threshold: INITIAL_THRESHOLD,
     boxes_start: None,
     boxes_end: ptr::null_mut(),
 }));
@@ -63,8 +70,15 @@ impl<T: Trace> GcBox<T> {
             let mut st = _st.borrow_mut();
 
             // XXX We should probably be more clever about collecting
-            if st.bytes_allocated > GC_THRESHOLD {
+            if st.bytes_allocated > st.threshold {
                 collect_garbage(&mut *st);
+
+                if st.bytes_allocated as f64 > st.threshold as f64 * USED_SPACE_RATIO  {
+                    // we didn't collect enough, so increase the
+                    // threshold for next time, to avoid thrashing the
+                    // collector too much/behaving quadratically.
+                    st.threshold = (st.bytes_allocated as f64 / USED_SPACE_RATIO) as usize
+                }
             }
 
             let mut gcbox = Box::new(GcBox {


### PR DESCRIPTION
This is still very naive, butavoids quadratic behaviour, by collecting
exponentially rarely as the heap grows. This cuts the run time of the
included `keep_10000` benchmark from an (estimated) 300 ms to ~1ms.

The failure case of the naive strategy is how often it collects when
growing to some heap size N (e.g. a graph structure with N nodes): if
the N is larger than the threshold, then at some point the live heap
size will have passed the threshold and every allocation will be trying
to collect. Each collection does O(size of heap) work as it scans the
heap, and each allocation is linearly increasing the size of heap, so to
get to a heap size of N, we do O(N) collections that involve O(N) work:
O(N^2).

By collecting exponentially rarely, getting to a heap size of N takes
one collection of size O(N), one of size O(N r), one of size O(N
r^2) (for some r < 1), which is O(N) in total. (I chose r somewhat
randomly to be 0.7 in this patch.)