### PR TITLE
Remove compiletest dependency

### DIFF
--- a/gc/Cargo.toml
+++ b/gc/Cargo.toml
@@ -11,5 +11,3 @@ keywords = ["garbage", "plugin", "memory"]
 [dependencies.gc_plugin]
 path = "../gc_plugin"
 version = "0.0.4"
-[dev-dependencies]
-compiletest_rs = "*"


### PR DESCRIPTION
It didn't appear to be used. Since compiletest also doesn't support Windows directly (without MSYS), this makes testing on Windows easier.