### PR TITLE
Some run-of-the-mill fixes

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -13,6 +13,7 @@ use gc::GcBox;
 use std::cell::{self, Cell, RefCell, BorrowState};
 use std::ops::{Deref, DerefMut, CoerceUnsized};
 use std::marker;
+use std::fmt::*;
 
 mod gc;
 mod trace;
@@ -254,5 +255,12 @@ impl<'a, T: Trace + ?Sized> Drop for GcCellRefMut<'a, T> {
         if !self._rooted.get() {
             unsafe { self._ref.unroot(); }
         }
+    }
+}
+
+
+impl Debug for Gc<String> {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "{}", **self)
     }
 }

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -63,6 +63,8 @@ unsafe impl<T: ?Sized> Trace for &'static T {
     unsafe_empty_trace!();
 }
 
+unsafe impl Trace for usize { unsafe_empty_trace!(); }
+unsafe impl Trace for bool { unsafe_empty_trace!(); }
 unsafe impl Trace for i8  { unsafe_empty_trace!(); }
 unsafe impl Trace for u8  { unsafe_empty_trace!(); }
 unsafe impl Trace for i16 { unsafe_empty_trace!(); }

--- a/gc_plugin/src/lib.rs
+++ b/gc_plugin/src/lib.rs
@@ -3,12 +3,13 @@
 
 #[macro_use]
 extern crate syntax;
+extern crate syntax_ext;
 #[macro_use]
 extern crate rustc;
+extern crate rustc_plugin;
 
 
-
-use rustc::plugin::Registry;
+use rustc_plugin::Registry;
 use syntax::parse::token::intern;
 
 use syntax::attr::AttrMetaMethods;
@@ -17,7 +18,7 @@ use syntax::codemap::Span;
 use syntax::ptr::P;
 use syntax::ast::{MetaItem, Expr};
 use syntax::ext::build::AstBuilder;
-use syntax::ext::deriving::generic::{combine_substructure, EnumMatching, FieldInfo, MethodDef, Struct, Substructure, TraitDef, ty};
+use syntax_ext::deriving::generic::{combine_substructure, EnumMatching, FieldInfo, MethodDef, Struct, Substructure, TraitDef, ty};
 
 
 #[plugin_registrar]


### PR DESCRIPTION
1. Derive `Debug` for `Gc<String>`
2. Derive `Trace` for `bool` and `usize`
3. Import `syntax_ext` and `rustc_plugin`, so it can compile on the nightly `rustc`