### PR TITLE
Updated gc_plugin to breaking changes in the nightly and fixed export of trace in gc

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -18,7 +18,7 @@ use core::cmp::Ordering;
 use core::hash::{Hasher, Hash};
 
 mod gc;
-mod trace;
+pub mod trace;
 
 // We re-export the Trace method, as well as some useful internal methods for
 // managing collections or configuring the garbage collector.
@@ -428,4 +428,3 @@ impl<T: Trace> From<T> for GcCell<T> {
         GcCell::new(t)
     }
 }
-

--- a/gc_plugin/src/lib.rs
+++ b/gc_plugin/src/lib.rs
@@ -42,7 +42,8 @@ pub fn expand_trace(cx: &mut ExtCtxt, span: Span, mitem: &MetaItem, item: &Annot
                 ret_ty: ty::nil_ty(),
                 attributes: vec![], // todo: handle inlining
                 is_unsafe: true,
-                combine_substructure: combine_substructure(box trace_substructure)
+                combine_substructure: combine_substructure(box trace_substructure),
+                unify_fieldless_variants: false,
             },
             MethodDef {
                 name: "root",
@@ -52,7 +53,8 @@ pub fn expand_trace(cx: &mut ExtCtxt, span: Span, mitem: &MetaItem, item: &Annot
                 ret_ty: ty::nil_ty(),
                 attributes: vec![],
                 is_unsafe: true,
-                combine_substructure: combine_substructure(box trace_substructure)
+                combine_substructure: combine_substructure(box trace_substructure),
+                unify_fieldless_variants: false,
             },
             MethodDef {
                 name: "unroot",
@@ -62,7 +64,8 @@ pub fn expand_trace(cx: &mut ExtCtxt, span: Span, mitem: &MetaItem, item: &Annot
                 ret_ty: ty::nil_ty(),
                 attributes: vec![],
                 is_unsafe: true,
-                combine_substructure: combine_substructure(box trace_substructure)
+                combine_substructure: combine_substructure(box trace_substructure),
+                unify_fieldless_variants: false,
             }
         ],
         associated_types: vec![],
@@ -92,7 +95,7 @@ fn trace_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure)
     let mut stmts = Vec::new();
 
     let fields = match *substr.fields {
-        Struct(ref fs) | EnumMatching(_, _, ref fs) => fs,
+        Struct(_, ref fs) | EnumMatching(_, _, ref fs) => fs,
         _ => cx.span_bug(trait_span, "impossible substructure in `#[derive(Trace)]`")
     };
 


### PR DESCRIPTION
The `unify_fieldless_variants` stuff comes from here: https://github.com/rust-lang/rust/commit/0eeb14eaba04025aa8a4612e1935f04f2ca3fb6b

I'm still not 100% clear on what it does, but I'm fairly certain the safest thing is to leave it off.

I'm also not sure why I have to export trace and not just use the existing `pub use trace::Trace`, but it appears to not compile if you don't export the `trace` module.