### PR TITLE
Fix printing of Gc with {:#?}

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -419,7 +419,7 @@ impl<T: Trace + ?Sized + fmt::Display> fmt::Display for GcCell<T> {
 
 impl<T: Trace + ?Sized + fmt::Debug> fmt::Debug for GcCell<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt:Debug::fmt(&*self.borrow(), f)
+        fmt::Debug::fmt(&*self.borrow(), f)
     }
 }
 

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -197,7 +197,7 @@ impl<T: Trace + ?Sized + fmt::Display> fmt::Display for Gc<T> {
     }
 }
 
-impl<T: fmt::Debug+Trace> fmt::Debug for Gc<T> {
+impl<T: Trace + ?Sized + fmt::Debug> fmt::Debug for Gc<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt:Debug::fmt(&**self, f)
     }
@@ -417,7 +417,7 @@ impl<T: Trace + ?Sized + fmt::Display> fmt::Display for GcCell<T> {
     }
 }
 
-impl<T: fmt::Debug+Trace> fmt::Debug for GcCell<T> {
+impl<T: Trace + ?Sized + fmt::Debug> fmt::Debug for GcCell<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt:Debug::fmt(&*self.borrow(), f)
     }

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -199,7 +199,7 @@ impl<T: Trace + ?Sized + fmt::Display> fmt::Display for Gc<T> {
 
 impl<T: Trace + ?Sized + fmt::Debug> fmt::Debug for Gc<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt:Debug::fmt(&**self, f)
+        fmt::Debug::fmt(&**self, f)
     }
 }
 

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -199,7 +199,7 @@ impl<T: Trace + ?Sized + fmt::Display> fmt::Display for Gc<T> {
 
 impl<T: fmt::Debug+Trace> fmt::Debug for Gc<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", **self)
+        fmt:Debug::fmt(&**self, f)
     }
 }
 
@@ -419,7 +419,7 @@ impl<T: Trace + ?Sized + fmt::Display> fmt::Display for GcCell<T> {
 
 impl<T: fmt::Debug+Trace> fmt::Debug for GcCell<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", *self.borrow())
+        fmt:Debug::fmt(&*self.borrow(), f)
     }
 }
 


### PR DESCRIPTION
The debug implementation created a new format string, always using {:?}, and therefore ignores any formatting parameters provided. This causes it to instead use the formatter provided.

Closes #30