### PR TITLE
Panic in Gc<T>.inner() instead of GcBox<T>.data()

### DIFF
--- a/gc/src/gc.rs
+++ b/gc/src/gc.rs
@@ -32,7 +32,7 @@ impl Drop for GcState {
 
 /// Whether or not the thread is currently in the sweep phase of garbage collection.
 /// During this phase, attempts to dereference a `Gc<T>` pointer will trigger a panic.
-thread_local!(static GC_SWEEPING: Cell<bool> = Cell::new(false));
+thread_local!(pub static GC_SWEEPING: Cell<bool> = Cell::new(false));
 
 /// The garbage collector's internal state.
 thread_local!(static GC_STATE: RefCell<GcState> = RefCell::new(GcState {
@@ -124,10 +124,6 @@ impl<T: Trace + ?Sized> GcBox<T> {
 
     /// Returns a reference to the `GcBox`'s value.
     pub fn value(&self) -> &T {
-        // XXX This may be too expensive, but will help catch errors with
-        // accessing Gc values in destructors.
-        GC_SWEEPING.with(|sweeping| assert!(!sweeping.get(),
-                                            "Gc pointers may be invalid when GC is running"));
         &self.data
     }
 

--- a/gc/src/test.rs
+++ b/gc/src/test.rs
@@ -1,0 +1,70 @@
+use super::{Gc, GcCell, Trace, force_collect};
+
+#[test]
+#[should_panic]
+fn test_issue36() {
+    struct Foo(GcCell<Option<Gc<Trace>>>);
+
+    unsafe impl Trace for Foo {
+        unsafe fn trace(&self) {
+            self.0.trace();
+        }
+
+        unsafe fn root(&self) {
+            self.0.root();
+        }
+
+        unsafe fn unroot(&self) {
+            self.0.unroot();
+        }
+    }
+
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            self.0.borrow().clone();
+        }
+    }
+
+    {
+        let a = Gc::new(Foo(GcCell::new(None)));
+        let b = Gc::new(1);
+        *a.0.borrow_mut() = Some(b);
+    }
+
+    force_collect();
+}
+
+#[test]
+#[should_panic]
+fn test_issue37() {
+    struct Foo(GcCell<Option<Gc<Trace>>>);
+
+    unsafe impl Trace for Foo {
+        unsafe fn trace(&self) {
+            self.0.trace();
+        }
+
+        unsafe fn root(&self) {
+            self.0.root();
+        }
+
+        unsafe fn unroot(&self) {
+            self.0.unroot();
+        }
+    }
+
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            self.0.borrow_mut();
+        }
+    }
+
+    {
+        let a = Gc::new(Foo(GcCell::new(None)));
+        let b = Gc::new(1);
+        *a.0.borrow_mut() = Some(b);
+    }
+
+    force_collect();
+}
+


### PR DESCRIPTION
This causes us to panic whenever accessing a potentially invalid
GcBox<T>, rather than only when accessing the value stored within this
GcBox<T>.

Fixes #36 and #37