### PR TITLE
Add support for stable rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: rust
 sudo: true
-rust: nightly
+rust:
+  - stable
+  - beta
+  - nightly
 script:
-- cd gc
-- cargo build
-- cargo test
+  - cd gc
+  - cargo build
+  - cargo test
+  - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo build --features nightly)
+  - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --features nightly)
 after_success: bash ../upload-docs.sh
 env:
   global:

--- a/gc/Cargo.toml
+++ b/gc/Cargo.toml
@@ -8,5 +8,8 @@ readme = "../README.md"
 license = "MPL-2.0"
 keywords = ["garbage", "plugin", "memory"]
 
+[features]
+nightly = []
+
 [dev-dependencies]
 gc_derive = { path = "../gc_derive", version = "0.2.1" }

--- a/gc/benches/alloc_in_a_loop.rs
+++ b/gc/benches/alloc_in_a_loop.rs
@@ -16,17 +16,25 @@ fn discard(b: &mut test::Bencher, n: usize) {
 fn keep(b: &mut test::Bencher, n: usize) {
     b.iter(|| {
         gc::force_collect();
-        (0..n).map(|_| {
-            gc::Gc::new(THING)
-        }).collect::<Vec<_>>()
+        (0..n)
+            .map(|_| gc::Gc::new(THING))
+            .collect::<Vec<_>>()
     })
 }
 
 #[bench]
-fn discard_100(b: &mut test::Bencher) { discard(b, 100) }
+fn discard_100(b: &mut test::Bencher) {
+    discard(b, 100)
+}
 #[bench]
-fn keep_100(b: &mut test::Bencher) { keep(b, 100) }
+fn keep_100(b: &mut test::Bencher) {
+    keep(b, 100)
+}
 #[bench]
-fn discard_10000(b: &mut test::Bencher) { discard(b, 10_000) }
+fn discard_10000(b: &mut test::Bencher) {
+    discard(b, 10_000)
+}
 #[bench]
-fn keep_10000(b: &mut test::Bencher) { keep(b, 10_000) }
+fn keep_10000(b: &mut test::Bencher) {
+    keep(b, 10_000)
+}

--- a/gc/src/gc.rs
+++ b/gc/src/gc.rs
@@ -94,7 +94,7 @@ impl<T: Trace> GcBox<T> {
             if st.bytes_allocated > st.threshold {
                 collect_garbage(&mut *st);
 
-                if st.bytes_allocated as f64 > st.threshold as f64 * USED_SPACE_RATIO  {
+                if st.bytes_allocated as f64 > st.threshold as f64 * USED_SPACE_RATIO {
                     // we didn't collect enough, so increase the
                     // threshold for next time, to avoid thrashing the
                     // collector too much/behaving quadratically.
@@ -158,8 +158,7 @@ fn collect_garbage(st: &mut GcState) {
         incoming: *mut Option<Shared<GcBox<Trace>>>,
         this: Shared<GcBox<Trace>>,
     }
-    unsafe fn mark(head: &mut Option<Shared<GcBox<Trace>>>)
-                   -> Vec<Unmarked> {
+    unsafe fn mark(head: &mut Option<Shared<GcBox<Trace>>>) -> Vec<Unmarked> {
         // Walk the tree, tracing and marking the nodes
         let mut mark_head = *head;
         while let Some(node) = mark_head {
@@ -192,7 +191,7 @@ fn collect_garbage(st: &mut GcState) {
         let _guard = DropGuard::new();
         for node in finalized.into_iter().rev() {
             if (**node.this).header.marked.get() {
-                continue
+                continue;
             }
             let incoming = node.incoming;
             let mut node = Box::from_raw(*node.this);
@@ -203,7 +202,9 @@ fn collect_garbage(st: &mut GcState) {
 
     unsafe {
         let unmarked = mark(&mut st.boxes_start);
-        if unmarked.is_empty() { return }
+        if unmarked.is_empty() {
+            return;
+        }
         for node in &unmarked {
             Trace::finalize_glue(&(**node.this).data);
         }

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -84,7 +84,10 @@ impl<T: Trace> Gc<T> {
             // When we create a Gc<T>, all pointers which have been moved to the
             // heap no longer need to be rooted, so we unroot them.
             (**ptr).value().unroot();
-            let gc = Gc { ptr_root: Cell::new(NonZero::new(*ptr)), marker: PhantomData };
+            let gc = Gc {
+                ptr_root: Cell::new(NonZero::new(*ptr)),
+                marker: PhantomData,
+            };
             gc.set_root();
             gc
         }
@@ -92,7 +95,8 @@ impl<T: Trace> Gc<T> {
 }
 
 /// Returns the given pointer with its root bit cleared.
-unsafe fn clear_root_bit<T: ?Sized + Trace>(ptr: NonZero<*const GcBox<T>>) -> NonZero<*const GcBox<T>> {
+unsafe fn clear_root_bit<T: ?Sized + Trace>(ptr: NonZero<*const GcBox<T>>)
+                                            -> NonZero<*const GcBox<T>> {
     let mut ptr = *ptr;
     *(&mut ptr as *mut *const GcBox<T> as *mut usize) &= !1;
     NonZero::new(ptr)
@@ -160,7 +164,9 @@ unsafe impl<T: Trace + ?Sized> Trace for Gc<T> {
     }
 
     #[inline]
-    fn finalize_glue(&self) { Finalize::finalize(self); }
+    fn finalize_glue(&self) {
+        Finalize::finalize(self);
+    }
 }
 
 impl<T: Trace + ?Sized> Clone for Gc<T> {
@@ -168,7 +174,10 @@ impl<T: Trace + ?Sized> Clone for Gc<T> {
     fn clone(&self) -> Self {
         unsafe {
             self.inner().root_inner();
-            let gc = Gc { ptr_root: Cell::new(self.ptr_root.get()), marker: PhantomData };
+            let gc = Gc {
+                ptr_root: Cell::new(self.ptr_root.get()),
+                marker: PhantomData,
+            };
             gc.set_root();
             gc
         }
@@ -189,7 +198,9 @@ impl<T: Trace + ?Sized> Drop for Gc<T> {
     fn drop(&mut self) {
         // If this pointer was a root, we should unroot it.
         if self.rooted() {
-            unsafe { self.inner().unroot_inner(); }
+            unsafe {
+                self.inner().unroot_inner();
+            }
         }
     }
 }
@@ -383,9 +394,7 @@ impl<T: Trace> GcCell<T> {
     /// Consumes the `GcCell`, returning the wrapped value.
     #[inline]
     pub fn into_inner(self) -> T {
-        unsafe {
-            self.cell.into_inner()
-        }
+        unsafe { self.cell.into_inner() }
     }
 }
 
@@ -501,7 +510,9 @@ impl<'a, T: Trace + ?Sized> Deref for GcCellRef<'a, T> {
     type Target = T;
 
     #[inline]
-    fn deref(&self) -> &T { self.value }
+    fn deref(&self) -> &T {
+        self.value
+    }
 }
 
 impl<'a, T: Trace + ?Sized> Drop for GcCellRef<'a, T> {
@@ -528,12 +539,16 @@ impl<'a, T: Trace + ?Sized> Deref for GcCellRefMut<'a, T> {
     type Target = T;
 
     #[inline]
-    fn deref(&self) -> &T { self.value }
+    fn deref(&self) -> &T {
+        self.value
+    }
 }
 
 impl<'a, T: Trace + ?Sized> DerefMut for GcCellRefMut<'a, T> {
     #[inline]
-    fn deref_mut(&mut self) -> &mut T { self.value }
+    fn deref_mut(&mut self) -> &mut T {
+        self.value
+    }
 }
 
 impl<'a, T: Trace + ?Sized> Drop for GcCellRefMut<'a, T> {
@@ -543,7 +558,9 @@ impl<'a, T: Trace + ?Sized> Drop for GcCellRefMut<'a, T> {
         // Restore the rooted state of the GcCell's contents to the state of the GcCell.
         // During the lifetime of the GcCellRefMut, the GcCell's contents are rooted.
         if !self.flags.get().rooted() {
-            unsafe { self.value.unroot(); }
+            unsafe {
+                self.value.unroot();
+            }
         }
         self.flags.set(self.flags.get().set_unused());
     }

--- a/gc/src/stable.rs
+++ b/gc/src/stable.rs
@@ -1,0 +1,55 @@
+//! This module contains minimal stable dummy implementations of NonZero and
+//! Shared, such that the same code can be used between the nightly and stable
+//! versions of rust-gc.
+
+use std::ops::Deref;
+use std::marker::PhantomData;
+
+/// See `::core::nonzero::NonZero`
+#[derive(Copy, Clone)]
+pub struct NonZero<T> {
+    p: T
+}
+
+impl<T> Deref for NonZero<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.p
+    }
+}
+
+impl<T> NonZero<T> {
+    pub unsafe fn new(p: T) -> NonZero<T> {
+        NonZero {
+            p: p
+        }
+    }
+}
+
+/// See `::std::prt::Shared`
+pub struct Shared<T: ?Sized> {
+    p: NonZero<*mut T>,
+    _pd: PhantomData<T>,
+}
+
+impl<T: ?Sized> Shared<T> {
+    pub unsafe fn new(p: *mut T) -> Self {
+        Shared {
+            p: NonZero::new(p),
+            _pd: PhantomData,
+        }
+    }
+}
+
+impl<T: ?Sized> Deref for Shared<T> {
+    type Target = *mut T;
+    fn deref(&self) -> &*mut T {
+        &self.p
+    }
+}
+
+impl<T: ?Sized> Clone for Shared<T> {
+    fn clone(&self) -> Self { *self }
+}
+
+impl<T: ?Sized> Copy for Shared<T> {}

--- a/gc/src/stable.rs
+++ b/gc/src/stable.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 /// See `::core::nonzero::NonZero`
 #[derive(Copy, Clone)]
 pub struct NonZero<T> {
-    p: T
+    p: T,
 }
 
 impl<T> Deref for NonZero<T> {
@@ -20,9 +20,7 @@ impl<T> Deref for NonZero<T> {
 
 impl<T> NonZero<T> {
     pub unsafe fn new(p: T) -> NonZero<T> {
-        NonZero {
-            p: p
-        }
+        NonZero { p: p }
     }
 }
 
@@ -49,7 +47,9 @@ impl<T: ?Sized> Deref for Shared<T> {
 }
 
 impl<T: ?Sized> Clone for Shared<T> {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 
 impl<T: ?Sized> Copy for Shared<T> {}

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -13,7 +13,7 @@ impl<T: ?Sized> Finalize for T {
 }
 
 /// The Trace trait, which needs to be implemented on garbage-collected objects.
-pub unsafe trait Trace : Finalize {
+pub unsafe trait Trace: Finalize {
     /// Marks all contained `Gc`s.
     unsafe fn trace(&self);
 
@@ -109,21 +109,7 @@ macro_rules! simple_empty_finalize_trace {
     }
 }
 
-simple_empty_finalize_trace![
-    usize,
-    bool,
-    i8,
-    u8,
-    i16,
-    u16,
-    i32,
-    u32,
-    i64,
-    u64,
-    f32,
-    f64,
-    String
-];
+simple_empty_finalize_trace![usize, bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, String];
 
 impl<T: Trace> Finalize for Box<T> {}
 unsafe impl<T: Trace> Trace for Box<T> {

--- a/gc/tests/finalize.rs
+++ b/gc/tests/finalize.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro, specialization)]
+#![cfg_attr(feature = "nightly", feature(specialization))]
 
 #[macro_use]
 extern crate gc_derive;

--- a/gc/tests/gc_semantics.rs
+++ b/gc/tests/gc_semantics.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro, specialization)]
+#![cfg_attr(feature = "nightly", feature(specialization))]
 
 #[macro_use]
 extern crate gc_derive;
@@ -89,7 +89,7 @@ unsafe impl Trace for GcWatch {
     }
 }
 
-#[derive(Trace)]
+#[derive(Trace, Finalize)]
 struct GcWatchCycle {
     watch: GcWatch,
     cycle: GcCell<Option<Gc<GcWatchCycle>>>,
@@ -246,6 +246,7 @@ fn gccell_rooting() {
     FLAGS.with(|f| assert_eq!(f.get(), GcWatchFlags::new(3, 1, 2, 1, 1)));
 }
 
+#[cfg(feature = "nightly")] // XXX: CoerceUnsize is unstable only
 #[test]
 fn trait_gc() {
     #[derive(Trace)]

--- a/gc/tests/gc_semantics.rs
+++ b/gc/tests/gc_semantics.rs
@@ -246,14 +246,19 @@ fn gccell_rooting() {
     FLAGS.with(|f| assert_eq!(f.get(), GcWatchFlags::new(3, 1, 2, 1, 1)));
 }
 
-#[cfg(feature = "nightly")] // XXX: CoerceUnsize is unstable only
+#[cfg(feature = "nightly")]
+// XXX: CoerceUnsize is unstable only
 #[test]
 fn trait_gc() {
     #[derive(Trace)]
     struct Bar;
-    trait Foo: Trace { fn f(&self) -> i32; }
+    trait Foo: Trace {
+        fn f(&self) -> i32;
+    }
     impl Foo for Bar {
-        fn f(&self) -> i32 { 10 }
+        fn f(&self) -> i32 {
+            10
+        }
     }
     fn use_trait_gc(x: Gc<Foo>) {
         assert_eq!(x.f(), 10);

--- a/gc/tests/gymnastics_cycle.rs
+++ b/gc/tests/gymnastics_cycle.rs
@@ -26,12 +26,12 @@ impl gc::Finalize for Cyclic {
 fn test_cycle() {
     {
         let mut gcs = vec![Gc::new(Cyclic {
-            prev: GcCell::new(None),
-            name: 0,
-        })];
+                               prev: GcCell::new(None),
+                               name: 0,
+                           })];
 
         for i in 1..4 {
-            let prev = gcs[i-1].clone();
+            let prev = gcs[i - 1].clone();
             gcs.push(Gc::new(Cyclic {
                 prev: GcCell::new(Some(prev)),
                 name: i as u8,

--- a/gc/tests/gymnastics_cycle.rs
+++ b/gc/tests/gymnastics_cycle.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro, specialization)]
+#![cfg_attr(feature = "nightly", feature(specialization))]
 
 #[macro_use]
 extern crate gc_derive;

--- a/gc/tests/trace_impl.rs
+++ b/gc/tests/trace_impl.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro, specialization)]
+#![cfg_attr(feature = "nightly", feature(specialization))]
 
 #[macro_use]
 extern crate gc_derive;
@@ -9,7 +9,7 @@ thread_local!(static X: RefCell<u8> = RefCell::new(0));
 
 use gc::Trace;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Finalize)]
 struct Foo;
 
 unsafe impl Trace for Foo {
@@ -24,12 +24,12 @@ unsafe impl Trace for Foo {
     fn finalize_glue(&self){}
 }
 
-#[derive(Trace, Clone)]
+#[derive(Trace, Clone, Finalize)]
 struct Bar {
     inner: Foo,
 }
 
-#[derive(Trace)]
+#[derive(Trace, Finalize)]
 struct Baz {
     a: Bar,
     b: Bar,

--- a/gc/tests/trace_impl.rs
+++ b/gc/tests/trace_impl.rs
@@ -19,9 +19,9 @@ unsafe impl Trace for Foo {
             *m = *m + 1;
         })
     }
-    unsafe fn root(&self){}
-    unsafe fn unroot(&self){}
-    fn finalize_glue(&self){}
+    unsafe fn root(&self) {}
+    unsafe fn unroot(&self) {}
+    fn finalize_glue(&self) {}
 }
 
 #[derive(Trace, Clone, Finalize)]
@@ -37,17 +37,17 @@ struct Baz {
 
 #[test]
 fn test() {
-    let bar = Bar{inner: Foo};
-    unsafe { bar.trace(); }
-    X.with(|x| {
-        assert!(*x.borrow() == 1)
-    });
+    let bar = Bar { inner: Foo };
+    unsafe {
+        bar.trace();
+    }
+    X.with(|x| assert!(*x.borrow() == 1));
     let baz = Baz {
         a: bar.clone(),
         b: bar.clone(),
     };
-    unsafe { baz.trace(); }
-    X.with(|x| {
-        assert!(*x.borrow() == 3)
-    });
+    unsafe {
+        baz.trace();
+    }
+    X.with(|x| assert!(*x.borrow() == 3));
 }

--- a/gc_derive/src/lib.rs
+++ b/gc_derive/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro, proc_macro_lib)]
-
 extern crate proc_macro;
 extern crate syn;
 extern crate synstructure;
@@ -76,5 +74,19 @@ pub fn derive_trace(input: TokenStream) -> TokenStream {
     };
 
     // Generate the final value as a TokenStream and return it
+    result.to_string().parse().unwrap()
+}
+
+#[proc_macro_derive(Finalize)]
+pub fn derive_finalize(input: TokenStream) -> TokenStream {
+    let source = input.to_string();
+    let ast = syn::parse_macro_input(&source).unwrap();
+
+    let name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    let result = quote! {
+        impl #impl_generics ::gc::Finalize for #name #ty_generics #where_clause { }
+    };
+
     result.to_string().parse().unwrap()
 }

--- a/upload-docs.sh
+++ b/upload-docs.sh
@@ -1,5 +1,7 @@
 set -e
-if ([ "$TRAVIS_BRANCH" == "master" ] || [ ! -z "$TRAVIS_TAG" ]) && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then 
+if ([ "$TRAVIS_BRANCH" == "master" ] || [ ! -z "$TRAVIS_TAG" ]) &&
+       [ "$TRAVIS_PULL_REQUEST" == "false" ] &&
+       [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
   cargo doc
   sudo pip install ghp-import
   ghp-import -n target/doc


### PR DESCRIPTION
In order to do this, when `--features nightly` is not enabled:
 - There is no default implementation of `Finalize`, meaning that it
 must be manually implemented (for example, by the new
 `#[derive(Finalize)]` custom derive implementation).
 - There is no support for `CoerceUnsize` so it is hard (impossible?) to
 create `Gc<T> where T: ?Sized`.
 - The tree now contains dummy no-op implementations of `Shared<T>` and
 `NotNull<T>`, which are used in stable rust.

Fixes #46