### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ use gc::Gc;
 
 #[derive(Trace, Finalize)]
 struct Foo {
-    x: Gc<Foo>,
+    x: Option<Gc<Foo>>,
     y: u8,
     // ...
 }
@@ -81,7 +81,7 @@ use bar::Baz;
 
 #[derive(Trace, Finalize)]
 struct Foo {
-    x: Gc<Foo>,
+    x: Option<Gc<Foo>>,
     #[unsafe_ignore_trace]
     y: Baz, // we are assuming that `Baz` doesn't contain any `Gc` objects
     // ...


### PR DESCRIPTION
I've changed two instances of struct fields whose type is a garbage-collected handle to the struct type itself. It seemed unlikely that there was a safe way to create instances of the type, a point which caused some confusion among readers. The type was changed to `Option<Gc<Foo>>`, which is I think is the right call, though it could also have been `Gc<Option<Foo>>`; I don't have much experience with the library, and if you think the second type is more idiomatic let me know.