### PR TITLE
Adds impls for more types in std

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![cfg_attr(feature = "nightly",
             feature(coerce_unsized,
+                    i128_type,
                     nonzero,
                     optin_builtin_traits,
                     shared,

--- a/gc/src/stable.rs
+++ b/gc/src/stable.rs
@@ -19,7 +19,7 @@ impl<T: ?Sized> Shared<T> {
     }
 
     pub fn as_ptr(&self) -> *mut T {
-        self.p.get()
+        self.p
     }
 }
 

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -1,5 +1,3 @@
-#[cfg_attr(nightly, feature(i128))]
-
 use std::collections::{BinaryHeap, BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
@@ -118,7 +116,7 @@ macro_rules! simple_empty_finalize_trace {
 simple_empty_finalize_trace![(), isize, usize, bool, i8, u8, i16, u16, i32,
     u32, i64, u64, f32, f64, char, String, Path, PathBuf];
 
-#[cfg(nightly)]
+#[cfg(feature = "nightly")]
 simple_empty_finalize_trace![i128, u128];
 
 macro_rules! array_finalize_trace {

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -113,7 +113,7 @@ macro_rules! simple_empty_finalize_trace {
     }
 }
 
-simple_empty_finalize_trace![isize, usize, bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, char, String, Path, PathBuf];
+simple_empty_finalize_trace![(), isize, usize, bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, char, String, Path, PathBuf];
 
 macro_rules! fn_finalize_trace_one {
     ($ty:ty $(,$args:ident)*) => {
@@ -139,9 +139,18 @@ macro_rules! fn_finalize_trace_group {
 }
 
 macro_rules! tuple_finalize_trace {
+    () => {};
     ($($args:ident),*) => {
         impl<$($args),*> Finalize for ($($args,)*) {}
-        unsafe impl<$($args),*> Trace for ($($args,)*) { unsafe_empty_trace!(); }
+        unsafe impl<$($args: $crate::Trace),*> Trace for ($($args,)*) {
+            custom_trace!(this, {
+                #[allow(non_snake_case, unused_unsafe)]
+                fn avoid_lints<$($args: $crate::Trace),*>(&($(ref $args,)*): &($($args,)*)) {
+                    unsafe { $(mark($args);)* }
+                }
+                avoid_lints(this)
+            });
+        }
     }
 }
 

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -109,7 +109,7 @@ macro_rules! simple_empty_finalize_trace {
     }
 }
 
-simple_empty_finalize_trace![(), isize, usize, bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, String];
+simple_empty_finalize_trace![(), isize, usize, bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, char, String];
 
 impl<T: Trace> Finalize for Box<T> {}
 unsafe impl<T: Trace> Trace for Box<T> {

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -1,4 +1,4 @@
-use std::collections::{BinaryHeap, BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BinaryHeap, BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque};
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
 
@@ -284,6 +284,15 @@ unsafe impl<K: Eq + Hash + Trace, V: Trace> Trace for HashMap<K, V> {
 
 impl<T: Eq + Hash + Trace> Finalize for HashSet<T> {}
 unsafe impl<T: Eq + Hash + Trace> Trace for HashSet<T> {
+    custom_trace!(this, {
+        for v in this.iter() {
+            mark(v);
+        }
+    });
+}
+
+impl<T: Eq + Hash + Trace> Finalize for LinkedList<T> {}
+unsafe impl<T: Eq + Hash + Trace> Trace for LinkedList<T> {
     custom_trace!(this, {
         for v in this.iter() {
             mark(v);

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -113,7 +113,7 @@ macro_rules! simple_empty_finalize_trace {
     }
 }
 
-simple_empty_finalize_trace![(), isize, usize, bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, char, String, Path, PathBuf];
+simple_empty_finalize_trace![isize, usize, bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, char, String, Path, PathBuf];
 
 macro_rules! fn_finalize_trace_one {
     ($ty:ty $(,$args:ident)*) => {
@@ -138,15 +138,23 @@ macro_rules! fn_finalize_trace_group {
     }
 }
 
-macro_rules! fn_finalize_trace {
+macro_rules! tuple_finalize_trace {
+    ($($args:ident),*) => {
+        impl<$($args),*> Finalize for ($($args,)*) {}
+        unsafe impl<$($args),*> Trace for ($($args,)*) { unsafe_empty_trace!(); }
+    }
+}
+
+macro_rules! table_based_finalize_trace {
     ($(($($args:ident),*);)*) => {
         $(
             fn_finalize_trace_group!($($args),*);
+            tuple_finalize_trace!($($args),*);
         )*
     }
 }
 
-fn_finalize_trace![
+table_based_finalize_trace![
     ();
     (A);
     (A, B);

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -1,3 +1,5 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::hash::Hash;
 use std::path::{Path, PathBuf};
 
 /// The Finalize trait. Can be specialized for a specific type to define
@@ -133,6 +135,44 @@ impl<T: Trace> Finalize for Option<T> {}
 unsafe impl<T: Trace> Trace for Option<T> {
     custom_trace!(this, {
         if let Some(ref v) = *this {
+            mark(v);
+        }
+    });
+}
+
+impl<K: Trace, V: Trace> Finalize for BTreeMap<K, V> {}
+unsafe impl<K: Trace, V: Trace> Trace for BTreeMap<K, V> {
+    custom_trace!(this, {
+        for (k, v) in this {
+            mark(k);
+            mark(v);
+        }
+    });
+}
+
+impl<T: Trace> Finalize for BTreeSet<T> {}
+unsafe impl<T: Trace> Trace for BTreeSet<T> {
+    custom_trace!(this, {
+        for v in this {
+            mark(v);
+        }
+    });
+}
+
+impl<K: Eq + Hash + Trace, V: Trace> Finalize for HashMap<K, V> {}
+unsafe impl<K: Eq + Hash + Trace, V: Trace> Trace for HashMap<K, V> {
+    custom_trace!(this, {
+        for (k, v) in this.iter() {
+            mark(k);
+            mark(v);
+        }
+    });
+}
+
+impl<T: Eq + Hash + Trace> Finalize for HashSet<T> {}
+unsafe impl<T: Eq + Hash + Trace> Trace for HashSet<T> {
+    custom_trace!(this, {
+        for v in this.iter() {
             mark(v);
         }
     });

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -115,6 +115,53 @@ macro_rules! simple_empty_finalize_trace {
 
 simple_empty_finalize_trace![(), isize, usize, bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, char, String, Path, PathBuf];
 
+macro_rules! fn_finalize_trace_one {
+    ($ty:ty $(,$args:ident)*) => {
+        impl<Ret $(,$args)*> Finalize for $ty {}
+        unsafe impl<Ret $(,$args)*> Trace for $ty { unsafe_empty_trace!(); }
+    }
+}
+macro_rules! fn_finalize_trace_group {
+    () => {
+        fn_finalize_trace_one!(extern "Rust" fn () -> Ret);
+        fn_finalize_trace_one!(extern "C" fn () -> Ret);
+        fn_finalize_trace_one!(unsafe extern "Rust" fn () -> Ret);
+        fn_finalize_trace_one!(unsafe extern "C" fn () -> Ret);
+    };
+    ($($args:ident),*) => {
+        fn_finalize_trace_one!(extern "Rust" fn ($($args),*) -> Ret, $($args),*);
+        fn_finalize_trace_one!(extern "C" fn ($($args),*) -> Ret, $($args),*);
+        fn_finalize_trace_one!(extern "C" fn ($($args),*, ...) -> Ret, $($args),*);
+        fn_finalize_trace_one!(unsafe extern "Rust" fn ($($args),*) -> Ret, $($args),*);
+        fn_finalize_trace_one!(unsafe extern "C" fn ($($args),*) -> Ret, $($args),*);
+        fn_finalize_trace_one!(unsafe extern "C" fn ($($args),*, ...) -> Ret, $($args),*);
+    }
+}
+
+macro_rules! fn_finalize_trace {
+    ($(($($args:ident),*);)*) => {
+        $(
+            fn_finalize_trace_group!($($args),*);
+        )*
+    }
+}
+
+fn_finalize_trace![
+    ();
+    (A);
+    (A, B);
+    (A, B, C);
+    (A, B, C, D);
+    (A, B, C, D, E);
+    (A, B, C, D, E, F);
+    (A, B, C, D, E, F, G);
+    (A, B, C, D, E, F, G, H);
+    (A, B, C, D, E, F, G, H, I);
+    (A, B, C, D, E, F, G, H, I, J);
+    (A, B, C, D, E, F, G, H, I, J, K);
+    (A, B, C, D, E, F, G, H, I, J, K, L);
+];
+
 impl<T: Trace> Finalize for Box<T> {}
 unsafe impl<T: Trace> Trace for Box<T> {
     custom_trace!(this, {

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 /// The Finalize trait. Can be specialized for a specific type to define
 /// finalization logic for that type.
 pub trait Finalize {
@@ -109,7 +111,7 @@ macro_rules! simple_empty_finalize_trace {
     }
 }
 
-simple_empty_finalize_trace![(), isize, usize, bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, char, String];
+simple_empty_finalize_trace![(), isize, usize, bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, char, String, Path, PathBuf];
 
 impl<T: Trace> Finalize for Box<T> {}
 unsafe impl<T: Trace> Trace for Box<T> {

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -109,7 +109,7 @@ macro_rules! simple_empty_finalize_trace {
     }
 }
 
-simple_empty_finalize_trace![usize, bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, String];
+simple_empty_finalize_trace![(), isize, usize, bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, String];
 
 impl<T: Trace> Finalize for Box<T> {}
 unsafe impl<T: Trace> Trace for Box<T> {

--- a/gc/tests/i128.rs
+++ b/gc/tests/i128.rs
@@ -1,0 +1,18 @@
+#![cfg_attr(feature = "nightly", feature(i128_type))]
+
+extern crate gc;
+
+#[allow(unused_imports)]
+use gc::Gc;
+
+#[cfg(feature = "nightly")]
+#[test]
+fn i128() {
+    Gc::new(0i128);
+}
+
+#[cfg(feature = "nightly")]
+#[test]
+fn u128() {
+    Gc::new(0u128);
+}


### PR DESCRIPTION
## [primitives](https://doc.rust-lang.org/std/#primitives)

 - [x] `()`
 - [x] [`isize`](https://doc.rust-lang.org/std/primitive.isize.html)
 - [x] [`char`](https://doc.rust-lang.org/std/primitive.char.html)
 - [x] [`i128`](https://doc.rust-lang.org/std/primitive.i128.html)
 - [x] [`u128`](https://doc.rust-lang.org/std/primitive.u128.html)
 - [x] [arrays](https://doc.rust-lang.org/std/primitive.array.html)
 - [x] [tuples](https://doc.rust-lang.org/std/primitive.tuple.html)

`{i,u}128` should be feature-gated behind a `nightly` feature.

There should be a decision about what the largest tuple arity to support will be -- compiling the impls for each different length it can increase compile times a lot.
For reference, `std` provides trait impls for up to 31-item arrays and 12-tuples.

## [`std::collections`](https://doc.rust-lang.org/std/collections/)

 - [x] [`BTreeMap`](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html)
 - [x] [`BTreeSet`](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html)
 - [x] [`BinaryHeap`](https://doc.rust-lang.org/std/collections/struct.BinaryHeap.html)
 - [x] [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html)
 - [x] [`HashSet`](https://doc.rust-lang.org/std/collections/struct.HashSet.html)
 - [x] [`LinkedList`](https://doc.rust-lang.org/std/collections/struct.LinkedList.html)
 - [x] [`VecDeque`](https://doc.rust-lang.org/std/collections/struct.VecDeque.html)

Does it make sense to make a custom singly-linked `GcLinkedList` type instead of or in addition to having `Gc<LinkedList>` be supported?

~## [`std::ffi`](https://doc.rust-lang.org/std/ffi/)~

 - ~[`CString`](https://doc.rust-lang.org/std/ffi/struct.CString.html)~
 - ~[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)~

~There should probably be some directions with regards to FFI and GC; does e.g. [`CString::into_raw`](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.from_raw) unroot?~

## [`std::path`](https://doc.rust-lang.org/std/path/)

 - [x] [`Path`](https://doc.rust-lang.org/std/path/struct.Path.html)
 - [x] [`PathBuf`](https://doc.rust-lang.org/std/path/struct.PathBuf.html)

## [`std::result`](https://doc.rust-lang.org/std/result/)

 - [x] [`Result`](https://doc.rust-lang.org/std/result/enum.Result.html)