### PR TITLE
Add raw pointer interface

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -17,7 +17,7 @@ use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::mem;
-use std::ptr::{self, NonNull};
+use std::ptr::NonNull;
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -11,13 +11,14 @@
                     specialization))]
 
 use gc::GcBox;
+use std::alloc::{Layout};
 use std::cell::{Cell, UnsafeCell};
 use std::cmp::Ordering;
 use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
-use std::mem;
-use std::ptr::NonNull;
+use std::mem::{self, align_of_val};
+use std::ptr::{self, NonNull};
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 
@@ -126,6 +127,23 @@ impl<T: Trace + ?Sized> Gc<T> {
         let ptr: *const T = &*this;
         mem::forget(this);
         ptr
+    }
+
+    pub unsafe fn from_raw(ptr: *const T) -> Self {
+        // Align the unsized value to the end of the GcBox.
+        // Because it is ?Sized, it will always be the last field in memory.
+        let align = align_of_val(&*ptr);
+        let layout = Layout::new::<GcBox<()>>();
+        let offset = (layout.size() + padding_needed_for_gc(align)) as isize;
+
+        // Reverse the offset to find the original GcBox.
+        let fake_ptr = ptr as *mut GcBox<T>;
+        let rc_ptr = set_data_ptr(fake_ptr, (ptr as *mut u8).offset(-offset));
+
+        Gc {
+            ptr_root: Cell::new(NonNull::new_unchecked(rc_ptr)),
+            marker: PhantomData,
+        }
     }
 }
 
@@ -650,4 +668,23 @@ impl<T: Trace + ?Sized + Debug> Debug for GcCell<T> {
             }
         }
     }
+}
+
+// Sets the data pointer of a `?Sized` raw pointer.
+//
+// For a slice/trait object, this sets the `data` field and leaves the rest
+// unchanged. For a sized raw pointer, this simply sets the pointer.
+unsafe fn set_data_ptr<T: ?Sized, U>(mut ptr: *mut T, data: *mut U) -> *mut T {
+    ptr::write(&mut ptr as *mut _ as *mut *mut u8, data as *mut u8);
+    ptr
+}
+
+fn padding_needed_for_gc(align: usize) -> usize {
+    assert!(align.count_ones() == 1, "align must be a power-of-two!");
+
+    // Determine how much our header is misaligned for `align`.
+    // `align - 1` is a mask of all bits less than the alignment,
+    // as `align` is a power-of-two.
+    let misaligned = mem::size_of::<GcBox<()>>() & (align - 1);
+    if misaligned > 0 { align - misaligned } else { 0 }
 }

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -151,8 +151,8 @@ impl<T: Trace + ?Sized> Gc<T> {
     /// [`Gc::into_raw`][into_raw].
     ///
     /// This function is unsafe because improper use may lead to memory
-    /// problems. For example, a double-free may occur if the function is called
-    /// twice on the same raw pointer.
+    /// problems. For example, a use-after-free will occur if the function is
+    /// called twice on the same raw pointer.
     ///
     /// [into_raw]: struct.Gc.html#method.into_raw
     ///

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -136,7 +136,7 @@ impl<T: Trace + ?Sized> Gc<T> {
     /// use gc::Gc;
     /// 
     /// let x = Gc::new(22);
-    /// let x_ptr = Gc::from_raw(x);
+    /// let x_ptr = Gc::into_raw(x);
     /// assert_eq!(unsafe { *x_ptr }, 22);
     /// ```
     pub fn into_raw(this: Self) -> *const T {

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -17,7 +17,7 @@ use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::mem;
-use std::ptr::NonNull;
+use std::ptr::{self, NonNull};
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 
@@ -118,6 +118,14 @@ impl<T: Trace + ?Sized> Gc<T> {
         assert!(finalizer_safe());
 
         unsafe { &*clear_root_bit(self.ptr_root.get()).as_ptr() }
+    }
+}
+
+impl<T: Trace + ?Sized> Gc<T> {
+    pub fn into_raw(this: Self) -> *const T {
+        let ptr: *const T = &*this;
+        mem::forget(this);
+        ptr
     }
 }
 


### PR DESCRIPTION
PR for #62. Aims to implement these methods:

```rust
fn into_raw(gc: Gc<T>) -> *const T { ... }
unsafe fn from_raw(ptr: *const T) -> Gc<T> { ... }
```

which are analogous to [`Rc::into_raw`](https://doc.rust-lang.org/std/rc/struct.Rc.html#method.into_raw), [`Rc::from_raw`](https://doc.rust-lang.org/std/rc/struct.Rc.html#method.from_raw).

Mostly just following the code from [`alloc/rc.rs`](https://doc.rust-lang.org/src/alloc/rc.rs.html#367).