### PR TITLE
Upgraded syn/quote dependencies for gc_derive

### DIFF
--- a/gc/tests/finalize.rs
+++ b/gc/tests/finalize.rs
@@ -4,7 +4,7 @@
 extern crate gc_derive;
 extern crate gc;
 
-use gc::Finalize;
+use gc::{Finalize, Trace};
 use std::cell::Cell;
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]

--- a/gc/tests/finalize.rs
+++ b/gc/tests/finalize.rs
@@ -4,8 +4,8 @@
 extern crate gc_derive;
 extern crate gc;
 
-use std::cell::Cell;
 use gc::Finalize;
+use std::cell::Cell;
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 struct Flags(i32, i32);
@@ -39,6 +39,9 @@ impl Finalize for B {
         });
     }
 }
+
+#[derive(Trace, Finalize)]
+struct X(Box<dyn Trace>);
 
 #[test]
 fn drop_triggers_finalize() {

--- a/gc/tests/gc_semantics.rs
+++ b/gc/tests/gc_semantics.rs
@@ -4,9 +4,9 @@
 extern crate gc_derive;
 extern crate gc;
 
-use gc::{force_collect, Finalize, Gc, GcCell, Trace};
 use std::cell::Cell;
 use std::thread::LocalKey;
+use gc::{Trace, Finalize, GcCell, Gc, force_collect};
 
 // Utility methods for the tests
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]

--- a/gc/tests/gc_semantics.rs
+++ b/gc/tests/gc_semantics.rs
@@ -4,9 +4,9 @@
 extern crate gc_derive;
 extern crate gc;
 
+use gc::{force_collect, Finalize, Gc, GcCell, Trace};
 use std::cell::Cell;
 use std::thread::LocalKey;
-use gc::{Trace, Finalize, GcCell, Gc, force_collect};
 
 // Utility methods for the tests
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]

--- a/gc_derive/Cargo.toml
+++ b/gc_derive/Cargo.toml
@@ -14,7 +14,7 @@ name = "gc_derive"
 proc-macro = true
 
 [dependencies]
-syn = "0.15"
-proc-macro2 = "0.4"
-quote = "0.6"
-synstructure = "0.10"
+syn = "1.0"
+proc-macro2 = "1.0"
+quote = "1.0"
+synstructure = "0.12"


### PR DESCRIPTION
I have noticed that in Boa, we have duplicated versions of these dependencies due to `gc` not being up to date. It seems that the update is backwards compatible and nothing breaks.

This also fixes #79, so I added a test for it.