### PR TITLE
Updated code to 2018 edition

### DIFF
--- a/gc/Cargo.toml
+++ b/gc/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/Manishearth/rust-gc"
 readme = "../README.md"
 license = "MPL-2.0"
 keywords = ["garbage", "plugin", "memory"]
+edition = "2018"
 
 [features]
 nightly = []

--- a/gc/benches/alloc_in_a_loop.rs
+++ b/gc/benches/alloc_in_a_loop.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
 
 extern crate test;
-extern crate gc;
 
 const THING: u64 = 0;
 

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -1,5 +1,5 @@
 use std::collections::{BinaryHeap, BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque};
-use std::hash::Hash;
+use std::hash::{Hash, BuildHasher};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicUsize};
 
@@ -248,7 +248,7 @@ unsafe impl<T: Trace, E: Trace> Trace for Result<T, E> {
 impl<T: Ord + Trace> Finalize for BinaryHeap<T> {}
 unsafe impl<T: Ord + Trace> Trace for BinaryHeap<T> {
     custom_trace!(this, {
-        for v in this.into_iter() {
+        for v in this.iter() {
             mark(v);
         }
     });
@@ -273,8 +273,8 @@ unsafe impl<T: Trace> Trace for BTreeSet<T> {
     });
 }
 
-impl<K: Eq + Hash + Trace, V: Trace> Finalize for HashMap<K, V> {}
-unsafe impl<K: Eq + Hash + Trace, V: Trace> Trace for HashMap<K, V> {
+impl<K: Eq + Hash + Trace, V: Trace, S: BuildHasher> Finalize for HashMap<K, V, S> {}
+unsafe impl<K: Eq + Hash + Trace, V: Trace, S: BuildHasher> Trace for HashMap<K, V, S> {
     custom_trace!(this, {
         for (k, v) in this.iter() {
             mark(k);
@@ -283,8 +283,8 @@ unsafe impl<K: Eq + Hash + Trace, V: Trace> Trace for HashMap<K, V> {
     });
 }
 
-impl<T: Eq + Hash + Trace> Finalize for HashSet<T> {}
-unsafe impl<T: Eq + Hash + Trace> Trace for HashSet<T> {
+impl<T: Eq + Hash + Trace, S: BuildHasher> Finalize for HashSet<T, S> {}
+unsafe impl<T: Eq + Hash + Trace, S: BuildHasher> Trace for HashSet<T, S> {
     custom_trace!(this, {
         for v in this.iter() {
             mark(v);

--- a/gc/tests/finalize.rs
+++ b/gc/tests/finalize.rs
@@ -1,10 +1,7 @@
 #![cfg_attr(feature = "nightly", feature(specialization))]
 
-#[macro_use]
-extern crate gc_derive;
-extern crate gc;
-
 use gc::{Finalize, Trace};
+use gc_derive::{Trace, Finalize};
 use std::cell::Cell;
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]

--- a/gc/tests/gc_semantics.rs
+++ b/gc/tests/gc_semantics.rs
@@ -1,12 +1,9 @@
 #![cfg_attr(feature = "nightly", feature(specialization))]
 
-#[macro_use]
-extern crate gc_derive;
-extern crate gc;
-
 use std::cell::Cell;
 use std::thread::LocalKey;
 use gc::{Trace, Finalize, GcCell, Gc, force_collect};
+use gc_derive::{Trace, Finalize};
 
 // Utility methods for the tests
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
@@ -21,11 +18,11 @@ struct GcWatchFlags {
 impl GcWatchFlags {
     fn new(trace: i32, root: i32, unroot: i32, drop: i32, finalize: i32) -> GcWatchFlags {
         GcWatchFlags {
-            trace: trace,
-            root: root,
-            unroot: unroot,
-            drop: drop,
-            finalize: finalize,
+            trace,
+            root,
+            unroot,
+            drop,
+            finalize,
         }
     }
 

--- a/gc/tests/gymnastics_cycle.rs
+++ b/gc/tests/gymnastics_cycle.rs
@@ -1,11 +1,8 @@
 #![cfg_attr(feature = "nightly", feature(specialization))]
 
-#[macro_use]
-extern crate gc_derive;
-extern crate gc;
-
 use std::cell::Cell;
 use gc::{GcCell, Gc, force_collect};
+use gc_derive::Trace;
 
 thread_local!(static COUNTER: Cell<u8> = Cell::new(0u8));
 

--- a/gc/tests/i128.rs
+++ b/gc/tests/i128.rs
@@ -1,7 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(i128_type))]
-
-extern crate gc;
-
 use gc::Gc;
 
 #[test]

--- a/gc/tests/trace_impl.rs
+++ b/gc/tests/trace_impl.rs
@@ -1,8 +1,6 @@
 #![cfg_attr(feature = "nightly", feature(specialization))]
 
-#[macro_use]
-extern crate gc_derive;
-extern crate gc;
+use gc_derive::{Trace, Finalize};
 use std::cell::RefCell;
 
 thread_local!(static X: RefCell<u8> = RefCell::new(0));
@@ -16,7 +14,7 @@ unsafe impl Trace for Foo {
     unsafe fn trace(&self) {
         X.with(|x| {
             let mut m = x.borrow_mut();
-            *m = *m + 1;
+            *m += 1;
         })
     }
     unsafe fn root(&self) {}

--- a/gc_derive/Cargo.toml
+++ b/gc_derive/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/Manishearth/rust-gc"
 readme = "../README.md"
 license = "MPL-2.0"
 keywords = ["garbage", "macro", "memory"]
+edition = "2018"
 
 [lib]
 name = "gc_derive"

--- a/gc_derive/src/lib.rs
+++ b/gc_derive/src/lib.rs
@@ -1,14 +1,9 @@
-extern crate proc_macro;
-extern crate syn;
-#[macro_use]
-extern crate synstructure;
-#[macro_use]
-extern crate quote;
-extern crate proc_macro2;
+use synstructure::{decl_derive, Structure};
+use quote::quote;
 
 decl_derive!([Trace, attributes(unsafe_ignore_trace)] => derive_trace);
 
-fn derive_trace(mut s: synstructure::Structure) -> proc_macro2::TokenStream {
+fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
     s.filter(|bi| !bi.ast().attrs.iter().any(|attr| attr.path.is_ident("unsafe_ignore_trace")));
     let trace_body = s.each(|bi| quote!(mark(#bi)));
 
@@ -67,6 +62,6 @@ fn derive_trace(mut s: synstructure::Structure) -> proc_macro2::TokenStream {
 
 decl_derive!([Finalize] => derive_finalize);
 
-fn derive_finalize(s: synstructure::Structure) -> proc_macro2::TokenStream {
+fn derive_finalize(s: Structure<'_>) -> proc_macro2::TokenStream {
     s.unbound_impl(quote!(::gc::Finalize), quote!())
 }


### PR DESCRIPTION
This PR adds the `edition = "2018"` setting to `Cargo.toml`, fixes all non-2018 edition idioms and a bunch of other Clippy lints, making the code more "idiomatic". I also ran `cargo fmt` to follow Rust code formatting conventions.