### PR TITLE
i128/u128 is stable for some time now

### DIFF
--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -118,7 +118,6 @@ simple_empty_finalize_trace![(), isize, usize, bool, i8, u8, i16, u16, i32,
     u32, i64, u64, f32, f64, char, String, Path, PathBuf, AtomicBool,
     AtomicIsize, AtomicUsize];
 
-#[cfg(feature = "nightly")]
 simple_empty_finalize_trace![i128, u128];
 
 macro_rules! array_finalize_trace {

--- a/gc/tests/i128.rs
+++ b/gc/tests/i128.rs
@@ -2,16 +2,13 @@
 
 extern crate gc;
 
-#[allow(unused_imports)]
 use gc::Gc;
 
-#[cfg(feature = "nightly")]
 #[test]
 fn i128() {
     Gc::new(0i128);
 }
 
-#[cfg(feature = "nightly")]
 #[test]
 fn u128() {
     Gc::new(0u128);


### PR DESCRIPTION
I removed the "nightly" feature from this implementation. This solves #80.