### PR TITLE
Added "derive" feature to avoid importing two crates

### DIFF
--- a/gc/Cargo.toml
+++ b/gc/Cargo.toml
@@ -11,6 +11,10 @@ edition = "2018"
 
 [features]
 nightly = []
+derive = ["gc_derive"]
+
+[dependencies]
+gc_derive = { path = "../gc_derive", version = "0.3", optional = true }
 
 [dev-dependencies]
 gc_derive = { path = "../gc_derive", version = "0.3" }

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -29,6 +29,9 @@ use std::ops::CoerceUnsized;
 mod gc;
 mod trace;
 
+#[cfg(feature = "derive")]
+pub use gc_derive::{Finalize, Trace};
+
 // We re-export the Trace method, as well as some useful internal methods for
 // managing collections or configuring the garbage collector.
 pub use crate::gc::{finalizer_safe, force_collect};


### PR DESCRIPTION
This adds the `derive` feature, similarly to how `serde` among others do it. This allows not depending on `gc_derive` from other crates, and we can just add the `derive` feature when importing the crate.