### PR TITLE
Added `Trace` implementation for `Box<str>`

### DIFF
--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -140,6 +140,7 @@ simple_empty_finalize_trace![
     f64,
     char,
     String,
+    Box<str>,
     Path,
     PathBuf,
     NonZeroIsize,

--- a/gc/tests/trace_impl.rs
+++ b/gc/tests/trace_impl.rs
@@ -32,6 +32,11 @@ struct InnerBoxSlice {
     inner: Box<[u32]>,
 }
 
+#[derive(Trace, Clone, Finalize)]
+struct InnerBoxStr {
+    inner: Box<str>,
+}
+
 #[derive(Trace, Finalize)]
 struct Baz {
     a: Bar,


### PR DESCRIPTION
This allows deriving `Trace` easily in any type where an inner member is a `Box<str>` which provides some space optimizations with respect to `String`.