### PR TITLE
Version bump

### DIFF
--- a/gc/Cargo.toml
+++ b/gc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc"
-version = "0.3.4"
+version = "0.3.6"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>", "Nika Layzell <nika@thelayzells.com>"]
 description = "Tracing garbage collector plugin for Rust. Not ready for use yet, please see README"
 repository = "https://github.com/Manishearth/rust-gc"


### PR DESCRIPTION
This bump the version to `gc` crate to `0.3.6`.

I'm confused as to why the version on master was `0.3.4` and on crates.io it was `0.3.5`