### PR TITLE
Don’t derive bogus generic bounds

### DIFF
--- a/gc/tests/derive_bounds.rs
+++ b/gc/tests/derive_bounds.rs
@@ -1,0 +1,15 @@
+#![cfg_attr(feature = "nightly", feature(specialization))]
+
+use gc_derive::{Finalize, Trace};
+use gc::Gc;
+
+// This impl should *not* require T: Trace.
+#[derive(Finalize, Trace)]
+struct Thunk<T>(fn() -> T);
+
+struct NotTrace;
+
+#[test]
+fn test_derive_bounds() {
+    let _: Gc<Thunk<NotTrace>> = Gc::new(Thunk(|| NotTrace));
+}

--- a/gc_derive/src/lib.rs
+++ b/gc_derive/src/lib.rs
@@ -1,5 +1,5 @@
 use quote::quote;
-use synstructure::{decl_derive, Structure};
+use synstructure::{decl_derive, AddBounds, Structure};
 
 decl_derive!([Trace, attributes(unsafe_ignore_trace)] => derive_trace);
 
@@ -12,6 +12,7 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
     });
     let trace_body = s.each(|bi| quote!(mark(#bi)));
 
+    s.add_bounds(AddBounds::Fields);
     let trace_impl = s.unsafe_bound_impl(
         quote!(::gc::Trace),
         quote! {


### PR DESCRIPTION
Deriving `Trace` for a generic `struct` only requires a `Trace` bound on all its field types. There’s no reason to also add a `Trace` bound for all its generic parameters.

Fixes #67.