### PR TITLE
Ignore fat pointer vtables for Gc::ptr_eq

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -90,7 +90,7 @@ impl<T: Trace> Gc<T> {
 impl<T: Trace + ?Sized> Gc<T> {
     /// Returns `true` if the two `Gc`s point to the same allocation.
     pub fn ptr_eq(this: &Gc<T>, other: &Gc<T>) -> bool {
-        ptr::eq(this.inner(), other.inner())
+        GcBox::ptr_eq(this.inner(), other.inner())
     }
 }
 


### PR DESCRIPTION
Rust doesn’t guarantee that fat pointer comparison works as expected due to duplicated vtables:

https://github.com/rust-lang/rust/issues/46139