### PR TITLE
Fix deprecated trait object syntax warnings

### DIFF
--- a/gc/tests/gc_semantics.rs
+++ b/gc/tests/gc_semantics.rs
@@ -257,12 +257,12 @@ fn trait_gc() {
             10
         }
     }
-    fn use_trait_gc(x: Gc<Foo>) {
+    fn use_trait_gc(x: Gc<dyn Foo>) {
         assert_eq!(x.f(), 10);
     }
 
     let gc_bar = Gc::new(Bar);
-    let gc_foo: Gc<Foo> = gc_bar.clone();
+    let gc_foo: Gc<dyn Foo> = gc_bar.clone();
 
     use_trait_gc(gc_foo);
     use_trait_gc(gc_bar);


### PR DESCRIPTION
From `cd gc; cargo test --features=nightly`:

```
warning: trait objects without an explicit `dyn` are deprecated
   --> gc/tests/gc_semantics.rs:260:27
    |
260 |     fn use_trait_gc(x: Gc<Foo>) {
    |                           ^^^ help: use `dyn`: `dyn Foo`
    |
    = note: `#[warn(bare_trait_objects)]` on by default

warning: trait objects without an explicit `dyn` are deprecated
   --> gc/tests/gc_semantics.rs:265:20
    |
265 |     let gc_foo: Gc<Foo> = gc_bar.clone();
    |                    ^^^ help: use `dyn`: `dyn Foo`
```