### PR TITLE
Remove unnecessary mark call in gc.rs file.

### DIFF
--- a/gc/src/gc.rs
+++ b/gc/src/gc.rs
@@ -213,7 +213,6 @@ fn collect_garbage(st: &mut GcState) {
         for node in &unmarked {
             Trace::finalize_glue(&(*node.this.as_ptr()).data);
         }
-        mark(&mut st.boxes_start);
         sweep(unmarked, &mut st.bytes_allocated);
     }
 }


### PR DESCRIPTION
In the `gc.rs` file, the line 216 seemed unnecessary to me while reading the code. I deleted that line and tried the tests via `cargo test` and `cargo test --release`, they both passed. Can you verify that it is unnecessary and merge this PR? Otherwise, if that line is necessary, I think we need a test case about that.