### PR TITLE
Gc::from_raw: Set the Gc as a root

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -195,10 +195,12 @@ impl<T: Trace + ?Sized> Gc<T> {
         let fake_ptr = ptr as *mut GcBox<T>;
         let rc_ptr = set_data_ptr(fake_ptr, (ptr as *mut u8).offset(-offset));
 
-        Gc {
+        let gc = Gc {
             ptr_root: Cell::new(NonNull::new_unchecked(rc_ptr)),
             marker: PhantomData,
-        }
+        };
+        gc.set_root();
+        gc
     }
 }
 

--- a/gc/tests/from_raw.rs
+++ b/gc/tests/from_raw.rs
@@ -1,0 +1,10 @@
+use gc::Gc;
+
+#[test]
+fn test_into_raw() {
+    let x = Gc::new(22);
+    let x_ptr = Gc::into_raw(x);
+    let x = unsafe { Gc::from_raw(x_ptr) };
+    let y = Gc::new(x);
+    assert_eq!(**y, 22);
+}


### PR DESCRIPTION
The recovered `Gc` is not inside a `GcBox` on the heap, so it must be set as a root (like it must have been when it was originally passed to `Gc::into_raw`). Otherwise, putting it into another `Gc` will panic with “`Can't double-unroot a Gc<T>`”.