### PR TITLE
GcCellRefMut::drop: Unroot the right value after GcCellRefMut::map

### DIFF
--- a/gc/tests/gc_cell_ref.rs
+++ b/gc/tests/gc_cell_ref.rs
@@ -1,0 +1,8 @@
+use gc::{Gc, GcCell, GcCellRefMut};
+
+#[test]
+fn test_gc_cell_ref_mut_map() {
+    let a = Gc::new(GcCell::new((0, Gc::new(1))));
+    *GcCellRefMut::map(a.borrow_mut(), |(n, _)| n) = 2;
+    assert_eq!(a.borrow_mut().0, 2);
+}


### PR DESCRIPTION
Fixes #117.