### PR TITLE
Gc::from_raw: Rely only on documented guarantees to compute layout

### DIFF
--- a/gc/src/gc.rs
+++ b/gc/src/gc.rs
@@ -72,6 +72,7 @@ pub(crate) struct GcBoxHeader {
     marked: Cell<bool>,
 }
 
+#[repr(C)] // to justify the layout computation in Gc::from_raw
 pub(crate) struct GcBox<T: Trace + ?Sized + 'static> {
     header: GcBoxHeader,
     data: T,

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -872,7 +872,9 @@ impl<'a, T: Trace + ?Sized, U: ?Sized> Drop for GcCellRefMut<'a, T, U> {
                 (*self.gc_cell.cell.get()).unroot();
             }
         }
-        self.gc_cell.flags.set(self.gc_cell.flags.get().set_unused());
+        self.gc_cell
+            .flags
+            .set(self.gc_cell.flags.get().set_unused());
     }
 }
 


### PR DESCRIPTION
The claim “Because it is `?Sized`, it will always be the last field in memory” was not reliable: the `?Sized` type may in fact be `Sized` (which the compiler will know after monomorphization), and in any case, the language provides no guarantees about the layout of `repr(Rust)` structs.

Switch `GcBox` to `repr(C)`, and rewrite the layout computation based on `Layout::extend`, which has a [documented guarantee](https://doc.rust-lang.org/std/alloc/struct.Layout.html#method.extend) to match the layout of `repr(C)` structs.

(`RcBox` in the standard library [is `repr(C)`](https://doc.rust-lang.org/1.49.0/src/alloc/rc.rs.html#273-281) for the same reason.)

Cc @ravern