### PR TITLE
Replace feature(specialization) with feature(min_specialization)

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![cfg_attr(
     feature = "nightly",
-    feature(coerce_unsized, auto_traits, unsize, specialization)
+    feature(coerce_unsized, auto_traits, unsize, min_specialization)
 )]
 
 use crate::gc::GcBox;

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -872,7 +872,9 @@ impl<'a, T: Trace + ?Sized, U: ?Sized> Drop for GcCellRefMut<'a, T, U> {
                 (*self.gc_cell.cell.get()).unroot();
             }
         }
-        self.gc_cell.flags.set(self.gc_cell.flags.get().set_unused());
+        self.gc_cell
+            .flags
+            .set(self.gc_cell.flags.get().set_unused());
     }
 }
 

--- a/gc/tests/finalize.rs
+++ b/gc/tests/finalize.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(specialization))]
+#![cfg_attr(feature = "nightly", feature(min_specialization))]
 
 use gc::{Finalize, Trace};
 use gc_derive::{Finalize, Trace};

--- a/gc/tests/gc_semantics.rs
+++ b/gc/tests/gc_semantics.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(specialization))]
+#![cfg_attr(feature = "nightly", feature(min_specialization))]
 
 use gc::{force_collect, Finalize, Gc, GcCell, Trace};
 use gc_derive::{Finalize, Trace};

--- a/gc/tests/gymnastics_cycle.rs
+++ b/gc/tests/gymnastics_cycle.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(specialization))]
+#![cfg_attr(feature = "nightly", feature(min_specialization))]
 
 use gc::{force_collect, Gc, GcCell};
 use gc_derive::Trace;

--- a/gc/tests/trace_impl.rs
+++ b/gc/tests/trace_impl.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(specialization))]
+#![cfg_attr(feature = "nightly", feature(min_specialization))]
 
 use gc_derive::{Finalize, Trace};
 use std::cell::RefCell;

--- a/gc/tests/unsized.rs
+++ b/gc/tests/unsized.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(specialization))]
+#![cfg_attr(feature = "nightly", feature(min_specialization))]
 
 use gc::{Gc, Trace};
 use gc_derive::{Finalize, Trace};


### PR DESCRIPTION
`feature(specialization)` is known to be unsound and emits a scary warning at build time that suggests using `feature(min_specialization)` instead.

(See discussion at rust-lang/rust#31844.)