### PR TITLE
Remove unused feature(auto_traits)

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -872,7 +872,9 @@ impl<'a, T: Trace + ?Sized, U: ?Sized> Drop for GcCellRefMut<'a, T, U> {
                 (*self.gc_cell.cell.get()).unroot();
             }
         }
-        self.gc_cell.flags.set(self.gc_cell.flags.get().set_unused());
+        self.gc_cell
+            .flags
+            .set(self.gc_cell.flags.get().set_unused());
     }
 }
 

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -4,10 +4,7 @@
 //! It is marked as non-sendable because the garbage collection only occurs
 //! thread-locally.
 
-#![cfg_attr(
-    feature = "nightly",
-    feature(coerce_unsized, auto_traits, unsize, specialization)
-)]
+#![cfg_attr(feature = "nightly", feature(coerce_unsized, unsize, specialization))]
 
 use crate::gc::GcBox;
 use std::alloc::Layout;


### PR DESCRIPTION
I converted this from `feature(optin_builtin_traits)` in #111, but in fact this has been unused since #51 removed the explicit negative impls for `!Send` and `!Sync`.