### PR TITLE
Remove feature(specialization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ struct Foo {
 // now, `Gc<Foo>` may be used
 ```
 
-> NOTE: Finalize is automatically implemented on all types when the `nightly`
-> feature is enabled through specialization.
-
 `Finalize` may also be implemented directly on the struct, in order to add custom finalizer behavior:
 
 ```rust

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -4,7 +4,7 @@
 //! It is marked as non-sendable because the garbage collection only occurs
 //! thread-locally.
 
-#![cfg_attr(feature = "nightly", feature(coerce_unsized, unsize, specialization))]
+#![cfg_attr(feature = "nightly", feature(coerce_unsized, unsize))]
 
 use crate::gc::GcBox;
 use std::alloc::Layout;

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -11,18 +11,10 @@ use std::sync::atomic::{
     AtomicU64, AtomicU8, AtomicUsize,
 };
 
-/// The Finalize trait. Can be specialized for a specific type to define
-/// finalization logic for that type.
+/// The Finalize trait, which needs to be implemented on
+/// garbage-collected objects to define finalization logic.
 pub trait Finalize {
     fn finalize(&self) {}
-}
-
-#[cfg(feature = "nightly")]
-impl<T: ?Sized> Finalize for T {
-    // XXX: Should this function somehow tell its caller (which is presumably
-    // the GC runtime) that it did nothing?
-    #[inline]
-    default fn finalize(&self) {}
 }
 
 /// The Trace trait, which needs to be implemented on garbage-collected objects.

--- a/gc/tests/finalize.rs
+++ b/gc/tests/finalize.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(specialization))]
-
 use gc::{Finalize, Trace};
 use gc_derive::{Finalize, Trace};
 use std::cell::Cell;

--- a/gc/tests/gc_semantics.rs
+++ b/gc/tests/gc_semantics.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(specialization))]
-
 use gc::{force_collect, Finalize, Gc, GcCell, Trace};
 use gc_derive::{Finalize, Trace};
 use std::cell::Cell;
@@ -247,7 +245,7 @@ fn gccell_rooting() {
 // XXX: CoerceUnsize is unstable only
 #[test]
 fn trait_gc() {
-    #[derive(Trace)]
+    #[derive(Finalize, Trace)]
     struct Bar;
     trait Foo: Trace {
         fn f(&self) -> i32;

--- a/gc/tests/gymnastics_cycle.rs
+++ b/gc/tests/gymnastics_cycle.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(specialization))]
-
 use gc::{force_collect, Gc, GcCell};
 use gc_derive::Trace;
 use std::cell::Cell;

--- a/gc/tests/trace_impl.rs
+++ b/gc/tests/trace_impl.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(specialization))]
-
 use gc_derive::{Finalize, Trace};
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/gc/tests/unsized.rs
+++ b/gc/tests/unsized.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(specialization))]
-
 use gc::{Gc, Trace};
 use gc_derive::{Finalize, Trace};
 


### PR DESCRIPTION
`feature(specialization)` as currently implemented in nightly Rust is known to be unsound.

Furthermore, using specialization for `Trace` was also forcing any downstream crate that implements `Trace` to itself enable `feature(specialization)`. This made turning on the `nightly` crate feature a backwards-incompatible change that violates additivity of features, and would cause compilation problems under feature unification.

Fixes #128.