### PR TITLE
Remove unnecessary feature(specialization) from test

### DIFF
--- a/gc/tests/derive_bounds.rs
+++ b/gc/tests/derive_bounds.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(specialization))]
-
 use gc_derive::{Finalize, Trace};
 use gc::Gc;
 


### PR DESCRIPTION
This became unnecessary upon the combination of #113 with #129.