### PR TITLE
Add trace for Cow

### DIFF
--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{
     AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicU16, AtomicU32,
     AtomicU64, AtomicU8, AtomicUsize,
 };
+use std::cow::Cow;
 
 /// The Finalize trait, which needs to be implemented on
 /// garbage-collected objects to define finalization logic.
@@ -361,6 +362,15 @@ impl<T: Trace> Finalize for VecDeque<T> {}
 unsafe impl<T: Trace> Trace for VecDeque<T> {
     custom_trace!(this, {
         for v in this.iter() {
+            mark(v);
+        }
+    });
+}
+
+impl<'a, T: ToOwned + Trace + ?Sized> Finalize for Cow<'a, T> {}
+unsafe impl<T: ToOwned + Trace + ?Sized> Trace for Cow<'a, T> {
+    custom_trace!(this, {
+        if let Cow::Owned(ref v) = this {
             mark(v);
         }
     });


### PR DESCRIPTION
Added trace and finalize implementation for `std::borrow::Cow`. I think I have done this correctly, where it only marks if it is the owned variant. Not particularly sure