### PR TITLE
Remove Trace implementation for Rc

### DIFF
--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -237,22 +237,6 @@ type_arg_tuple_based_finalize_trace_impls![
     (A, B, C, D, E, F, G, H, I, J, K, L);
 ];
 
-impl<T: Trace + ?Sized> Finalize for Rc<T> {}
-unsafe impl<T: Trace + ?Sized> Trace for Rc<T> {
-    custom_trace!(this, {
-        mark(&**this);
-    });
-}
-
-impl<T: Trace> Finalize for Rc<[T]> {}
-unsafe impl<T: Trace> Trace for Rc<[T]> {
-    custom_trace!(this, {
-        for e in this.iter() {
-            mark(e);
-        }
-    });
-}
-
 impl<T: Trace + ?Sized> Finalize for Box<T> {}
 unsafe impl<T: Trace + ?Sized> Trace for Box<T> {
     custom_trace!(this, {

--- a/gc/tests/trace_impl.rs
+++ b/gc/tests/trace_impl.rs
@@ -46,11 +46,6 @@ struct InnerRcStr {
     inner: Rc<str>,
 }
 
-#[derive(Trace, Clone, Finalize)]
-struct InnerRcStruct {
-    inner: Rc<Bar>,
-}
-
 #[derive(Trace, Finalize)]
 struct Baz {
     a: Bar,


### PR DESCRIPTION
I’m not sure if these impls would work with a better tracing algorithm, but they do not work correctly with this one.

```rust
let r = Rc::new(Gc::new(()));
Gc::new((Rc::clone(&r), r));
// → thread 'main' panicked at 'Can't double-unroot a Gc<T>'
```

Fixes #134.

I’m open to other suggestions, but I suspect the right way to support `Rc<T>` would be with a trait that marks `T` as containing no `Gc` dependencies (#109). Meanwhile, a user who needs such an `Rc<T>` can `#[unsafe_ignore_trace]`.