### PR TITLE
Generalize Trace impls for unsized types

### DIFF
--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -337,8 +337,8 @@ unsafe impl<T: Eq + Hash + Trace> Trace for LinkedList<T> {
     });
 }
 
-impl<T> Finalize for PhantomData<T> {}
-unsafe impl<T> Trace for PhantomData<T> {
+impl<T: ?Sized> Finalize for PhantomData<T> {}
+unsafe impl<T: ?Sized> Trace for PhantomData<T> {
     unsafe_empty_trace!();
 }
 

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -244,10 +244,10 @@ unsafe impl<T: Trace + ?Sized> Trace for Box<T> {
     });
 }
 
-impl<T: Trace> Finalize for Box<[T]> {}
-unsafe impl<T: Trace> Trace for Box<[T]> {
+impl<T: Trace> Finalize for [T] {}
+unsafe impl<T: Trace> Trace for [T] {
     custom_trace!(this, {
-        for e in this.iter() {
+        for e in this {
             mark(e);
         }
     });

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -135,7 +135,7 @@ simple_empty_finalize_trace![
     f64,
     char,
     String,
-    Box<str>,
+    str,
     Rc<str>,
     Path,
     PathBuf,

--- a/gc/tests/phantom_data.rs
+++ b/gc/tests/phantom_data.rs
@@ -9,4 +9,5 @@ enum Uninhabited {}
 #[test]
 fn phantom_data() {
     let _x: Gc<PhantomData<Uninhabited>> = Gc::new(PhantomData);
+    let _: Gc<PhantomData<str>> = Gc::new(PhantomData);
 }

--- a/gc/tests/unsized.rs
+++ b/gc/tests/unsized.rs
@@ -25,3 +25,14 @@ fn gc_dyn_foo() {
 fn gc_box_anyfoo(b: Box<AnyFoo>) -> Gc<Box<AnyFoo>> {
     Gc::new(b)
 }
+
+#[test]
+fn gc_box_slice() {
+    let _: Gc<Box<[u32]>> = Gc::new(Box::new([0, 1, 2]));
+}
+
+#[cfg(feature = "nightly")]
+#[test]
+fn gc_slice() {
+    let _: Gc<[u32]> = Gc::new([0, 1, 2]);
+}

--- a/gc/tests/unsized.rs
+++ b/gc/tests/unsized.rs
@@ -36,3 +36,14 @@ fn gc_box_slice() {
 fn gc_slice() {
     let _: Gc<[u32]> = Gc::new([0, 1, 2]);
 }
+
+#[test]
+fn gc_box_str() {
+    let _: Gc<Box<str>> = Gc::new(Box::from("hello"));
+}
+
+#[cfg(feature = "nightly")]
+#[allow(dead_code)]
+fn gc_str(_: Gc<str>) {
+    // no way to construct this yet
+}


### PR DESCRIPTION
- `impl<T: Trace> Trace for Box<[T]>` →
  `impl<T: Trace> Trace for [T]`
- `impl Trace for Box<str>` →
  `impl Trace for str`
- `impl<T> Trace for PhantomData<T>` →
  `impl<T: ?Sized> Trace for PhantomData<T>`