### PR TITLE
Enable the derive feature when testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,4 @@ members = [
     "gc",
     "gc_derive",
 ]
+resolver = "2"

--- a/gc/Cargo.toml
+++ b/gc/Cargo.toml
@@ -20,5 +20,5 @@ gc_derive = { path = "../gc_derive", version = "0.4.1", optional = true }
 serde = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
-gc_derive = { path = "../gc_derive", version = "0.4.1" }
+gc = { path = ".", features = ["derive"] }
 serde_json = { version = "1.0.66" }

--- a/gc/tests/derive_bounds.rs
+++ b/gc/tests/derive_bounds.rs
@@ -1,5 +1,4 @@
-use gc_derive::{Finalize, Trace};
-use gc::Gc;
+use gc::{Finalize, Gc, Trace};
 
 // This impl should *not* require T: Trace.
 #[derive(Finalize, Trace)]

--- a/gc/tests/finalize.rs
+++ b/gc/tests/finalize.rs
@@ -1,5 +1,4 @@
 use gc::{Finalize, Trace};
-use gc_derive::{Finalize, Trace};
 use std::cell::Cell;
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]

--- a/gc/tests/gc_semantics.rs
+++ b/gc/tests/gc_semantics.rs
@@ -1,5 +1,4 @@
 use gc::{force_collect, Finalize, Gc, GcCell, Trace};
-use gc_derive::{Finalize, Trace};
 use std::cell::Cell;
 use std::thread::LocalKey;
 

--- a/gc/tests/gymnastics_cycle.rs
+++ b/gc/tests/gymnastics_cycle.rs
@@ -1,5 +1,4 @@
-use gc::{force_collect, Gc, GcCell};
-use gc_derive::Trace;
+use gc::{force_collect, Gc, GcCell, Trace};
 use std::cell::Cell;
 
 thread_local!(static COUNTER: Cell<u8> = Cell::new(0u8));

--- a/gc/tests/trace_impl.rs
+++ b/gc/tests/trace_impl.rs
@@ -1,10 +1,8 @@
-use gc_derive::{Finalize, Trace};
+use gc::{Finalize, Trace};
 use std::cell::RefCell;
 use std::rc::Rc;
 
 thread_local!(static X: RefCell<u8> = RefCell::new(0));
-
-use gc::Trace;
 
 #[derive(Copy, Clone, Finalize)]
 struct Foo;

--- a/gc/tests/unsized.rs
+++ b/gc/tests/unsized.rs
@@ -1,5 +1,4 @@
-use gc::{Gc, Trace};
-use gc_derive::{Finalize, Trace};
+use gc::{Finalize, Gc, Trace};
 
 trait Foo: Trace {}
 


### PR DESCRIPTION
Otherwise `cargo test --all-features` enables it anyway and breaks with ``error[E0252]: the name `Trace` is defined multiple times``.