### PR TITLE
Implement From<Box<T>> for Gc<T>

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -379,6 +379,19 @@ impl<T: Trace> From<T> for Gc<T> {
     }
 }
 
+impl<
+        #[cfg(not(feature = "nightly"))] T: Trace,
+        #[cfg(feature = "nightly")] T: Trace + Unsize<dyn Trace> + ?Sized,
+    > From<Box<T>> for Gc<T>
+{
+    /// Moves a boxed value into a new garbage-collected
+    /// allocation. If the `nightly` crate feature is enabled, the
+    /// value may be an unsized trait object.
+    fn from(v: Box<T>) -> Gc<T> {
+        unsafe { Gc::from_gcbox(GcBox::from_box(v)) }
+    }
+}
+
 impl<T: Trace + ?Sized> std::borrow::Borrow<T> for Gc<T> {
     fn borrow(&self) -> &T {
         self

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -72,22 +72,30 @@ impl<T: Trace> Gc<T> {
     /// assert_eq!(*five, 5);
     /// ```
     pub fn new(value: T) -> Self {
-        assert!(mem::align_of::<GcBox<T>>() > 1);
+        unsafe { Gc::from_gcbox(GcBox::new(value)) }
+    }
+}
 
-        unsafe {
-            // Allocate the memory for the object
-            let ptr = GcBox::new(value);
+impl<T: Trace + ?Sized> Gc<T> {
+    /// Constructs a `Gc` that points to a new `GcBox`.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to a valid `GcBox` on the thread-local
+    /// `GcBox` chain.
+    #[inline]
+    unsafe fn from_gcbox(ptr: NonNull<GcBox<T>>) -> Gc<T> {
+        assert!(mem::align_of_val::<GcBox<T>>(ptr.as_ref()) > 1);
 
-            // When we create a Gc<T>, all pointers which have been moved to the
-            // heap no longer need to be rooted, so we unroot them.
-            ptr.as_ref().value().unroot();
-            let gc = Gc {
-                ptr_root: Cell::new(ptr),
-                marker: PhantomData,
-            };
-            gc.set_root();
-            gc
-        }
+        // When we create a Gc<T>, all pointers which have been moved to the
+        // heap no longer need to be rooted, so we unroot them.
+        ptr.as_ref().value().unroot();
+        let gc = Gc {
+            ptr_root: Cell::new(ptr),
+            marker: PhantomData,
+        };
+        gc.set_root();
+        gc
     }
 }
 

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -80,9 +80,9 @@ impl<T: Trace> Gc<T> {
 
             // When we create a Gc<T>, all pointers which have been moved to the
             // heap no longer need to be rooted, so we unroot them.
-            (*ptr.as_ptr()).value().unroot();
+            ptr.as_ref().value().unroot();
             let gc = Gc {
-                ptr_root: Cell::new(NonNull::new_unchecked(ptr.as_ptr())),
+                ptr_root: Cell::new(ptr),
                 marker: PhantomData,
             };
             gc.set_root();

--- a/gc/tests/from_box.rs
+++ b/gc/tests/from_box.rs
@@ -1,0 +1,20 @@
+use gc::{Finalize, Gc, Trace};
+
+trait Foo: Trace {}
+
+#[derive(Trace, Finalize)]
+struct Bar;
+impl Foo for Bar {}
+
+#[test]
+fn test_from_box_sized() {
+    let b: Box<[i32; 3]> = Box::new([1, 2, 3]);
+    let _: Gc<[i32; 3]> = Gc::from(b);
+}
+
+#[cfg(feature = "nightly")]
+#[test]
+fn test_from_box_dyn() {
+    let b: Box<dyn Foo> = Box::new(Bar);
+    let _: Gc<dyn Foo> = Gc::from(b);
+}


### PR DESCRIPTION
This is especially useful on nightly, where it works for unsized trait objects.

(Unsized slices cannot be supported with the current design, as there’s no conversion from `[T]` to `dyn Trace`: https://github.com/Manishearth/rust-gc/issues/2#issuecomment-1360513696.)

Fixes #72.