### PR TITLE
Allow trait objects with methods on `self: Gc<Self>` on nightly

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -4,7 +4,10 @@
 //! It is marked as non-sendable because the garbage collection only occurs
 //! thread-locally.
 
-#![cfg_attr(feature = "nightly", feature(coerce_unsized, unsize))]
+#![cfg_attr(
+    feature = "nightly",
+    feature(coerce_unsized, dispatch_from_dyn, unsize)
+)]
 
 use crate::gc::{GcBox, GcBoxHeader};
 use std::alloc::Layout;
@@ -21,7 +24,7 @@ use std::rc::Rc;
 #[cfg(feature = "nightly")]
 use std::marker::Unsize;
 #[cfg(feature = "nightly")]
-use std::ops::CoerceUnsized;
+use std::ops::{CoerceUnsized, DispatchFromDyn};
 
 mod gc;
 #[cfg(feature = "serde")]
@@ -55,6 +58,9 @@ pub struct Gc<T: ?Sized + 'static> {
 
 #[cfg(feature = "nightly")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Gc<U>> for Gc<T> {}
+
+#[cfg(feature = "nightly")]
+impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Gc<U>> for Gc<T> {}
 
 impl<T: Trace> Gc<T> {
     /// Constructs a new `Gc<T>` with the given value.

--- a/gc/src/serde.rs
+++ b/gc/src/serde.rs
@@ -10,7 +10,7 @@ impl<'de, T: Deserialize<'de> + Trace> Deserialize<'de> for Gc<T> {
     }
 }
 
-impl<T: Serialize + Trace> Serialize for Gc<T> {
+impl<T: Serialize> Serialize for Gc<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/gc/tests/gc_self_method.rs
+++ b/gc/tests/gc_self_method.rs
@@ -1,0 +1,21 @@
+#![cfg(feature = "nightly")]
+#![feature(arbitrary_self_types)]
+
+use gc::{Finalize, Gc, Trace};
+
+trait Foo: Trace {
+    fn foo(self: Gc<Self>);
+}
+
+#[derive(Trace, Finalize)]
+struct Bar;
+
+impl Foo for Bar {
+    fn foo(self: Gc<Bar>) {}
+}
+
+#[test]
+fn gc_self_method() {
+    let gc: Gc<dyn Foo> = Gc::new(Bar);
+    gc.foo();
+}


### PR DESCRIPTION
This requires `#![feature(arbitrary_self_types)]` and nightly 2023-01-27 or later for https://github.com/rust-lang/rust/pull/97373.