### PR TITLE
Allow dereferencing a rooted Gc during collection

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -141,12 +141,12 @@ impl<T: ?Sized> Gc<T> {
     #[inline]
     fn inner_ptr(&self) -> *mut GcBox<T> {
         // If we are currently in the dropping phase of garbage collection,
-        // it would be undefined behavior to dereference this pointer.
+        // it would be undefined behavior to dereference an unrooted Gc.
         // By opting into `Trace` you agree to not dereference this pointer
         // within your drop method, meaning that it should be safe.
         //
         // This assert exists just in case.
-        assert!(finalizer_safe());
+        assert!(finalizer_safe() || self.rooted());
 
         unsafe { clear_root_bit(self.ptr_root.get()).as_ptr() }
     }

--- a/gc/tests/ignore_trace.rs
+++ b/gc/tests/ignore_trace.rs
@@ -1,0 +1,12 @@
+use gc::{force_collect, Finalize, Gc, Trace};
+
+#[derive(Finalize, Trace)]
+struct S(#[unsafe_ignore_trace] Gc<()>);
+
+/// Using `#[unsafe_ignore_trace]` on a `Gc` may inhibit collection of
+/// cycles through that `Gc`, but it should not result in panics.
+#[test]
+fn ignore_trace_gc() {
+    Gc::new(S(Gc::new(())));
+    force_collect();
+}


### PR DESCRIPTION
Ordinarily, objects dropped during collections would only contain unrooted `Gc` pointers. But with `#[unsafe_ignore_trace]` it’s possible to smuggle a rooted `Gc` pointer into the heap. When we collect a rooted `Gc` pointer, we need to dereference it in order to unroot its contents. This should be safe because the associated allocation cannot have been collected while the `Gc` is rooted.

Fixes an `assertion failed: finalizer_safe()` panic in the included test case (refs #52).