### PR TITLE
Release 0.5.0

### DIFF
--- a/gc/Cargo.toml
+++ b/gc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>", "Nika Layzell <nika@thelayzells.com>"]
 description = "Tracing garbage collector plugin for Rust."
 repository = "https://github.com/Manishearth/rust-gc"
@@ -16,7 +16,7 @@ unstable-config = []
 unstable-stats = []
 
 [dependencies]
-gc_derive = { path = "../gc_derive", version = "0.4.1", optional = true }
+gc_derive = { path = "../gc_derive", version = "0.5.0", optional = true }
 serde = { version = "1.0.0", optional = true }
 
 [dev-dependencies]

--- a/gc_derive/Cargo.toml
+++ b/gc_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc_derive"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>", "Nika Layzell <nika@thelayzells.com>"]
 
 description = "Garbage collector derive plugin for rust-gc"


### PR DESCRIPTION
A bump for crates.io.

I haven't actually used this at this point, so I don't know if this is a good state to release, but since there haven't been any commits in a couple months so I assume it's relatively stable.