### PR TITLE
Add `#[track_caller]` to the `borrow` and `borrow_mut` of `GcCell`

### DIFF
--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -524,6 +524,7 @@ impl<T: ?Sized> GcCell<T> {
     ///
     /// Panics if the value is currently mutably borrowed.
     #[inline]
+    #[track_caller]
     pub fn borrow(&self) -> GcCellRef<'_, T> {
         match self.try_borrow() {
             Ok(value) => value,
@@ -542,6 +543,7 @@ impl<T: Trace + ?Sized> GcCell<T> {
     ///
     /// Panics if the value is currently borrowed.
     #[inline]
+    #[track_caller]
     pub fn borrow_mut(&self) -> GcCellRefMut<'_, T> {
         match self.try_borrow_mut() {
             Ok(value) => value,


### PR DESCRIPTION
Simply add `#[track_caller]` to the `borrow` and `borrow_mut` of `GcCell` so that the source will change to the file that call the method instead of the file of the method when they fail

For example
```
use gc::*;

#[test]
fn test_track_caller() {
    let cell = GcCell::new(1);

    let _borrow = cell.borrow();
    let _borrow_mut = cell.borrow_mut();
}
```

Before
```
running 1 test
thread 'test_track_caller' panicked at C:\Develop\Projects\Rust\rust-gc\gc\src\lib.rs:550:23:
GcCell<T> already borrowed
stack backtrace:
   0: rust_begin_unwind
             at /rustc/6ef7d16be0fb9d6ecf300c27990f4bff49d22d46/library\std\src/panicking.rs:617:5 
   1: core::panicking::panic_fmt
             at /rustc/6ef7d16be0fb9d6ecf300c27990f4bff49d22d46/library\core\src/panicking.rs:67:14
   2: core::panicking::panic_display
             at /rustc/6ef7d16be0fb9d6ecf300c27990f4bff49d22d46\library\core\src/panicking.rs:150:5   
   3: gc::GcCell<T>::borrow_mut
             at .\src\lib.rs:550:23
   4: track_caller::test_track_caller
             at .\tests\track_caller.rs:8:23
   5: track_caller::test_track_caller::{{closure}}
             at .\tests\track_caller.rs:4:24
   6: core::ops::function::FnOnce::call_once
             at /rustc/6ef7d16be0fb9d6ecf300c27990f4bff49d22d46\library\core\src\ops/function.rs:250:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/6ef7d16be0fb9d6ecf300c27990f4bff49d22d46/library\core\src\ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
test test_track_caller ... FAILED

failures:

failures:
    test_track_caller

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s

error: test failed, to rerun pass `-p gc --test track_caller`
```

After
```
running 1 test
thread 'test_track_caller' panicked at gc\tests\track_caller.rs:8:28:
GcCell<T> already borrowed
stack backtrace:
   0: rust_begin_unwind
             at /rustc/6ef7d16be0fb9d6ecf300c27990f4bff49d22d46/library\std\src/panicking.rs:617:5
   1: core::panicking::panic_fmt
             at /rustc/6ef7d16be0fb9d6ecf300c27990f4bff49d22d46/library\core\src/panicking.rs:67:14
   2: core::panicking::panic_display
             at /rustc/6ef7d16be0fb9d6ecf300c27990f4bff49d22d46\library\core\src/panicking.rs:150:5
   3: gc::GcCell<T>::borrow_mut
             at .\src\lib.rs:550:23
   4: track_caller::test_track_caller
             at .\tests\track_caller.rs:8:23
   5: track_caller::test_track_caller::{{closure}}
             at .\tests\track_caller.rs:4:24
   6: core::ops::function::FnOnce::call_once
             at /rustc/6ef7d16be0fb9d6ecf300c27990f4bff49d22d46\library\core\src\ops/function.rs:250:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/6ef7d16be0fb9d6ecf300c27990f4bff49d22d46/library\core\src\ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
test test_track_caller ... FAILED

failures:

failures:
    test_track_caller

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s

error: test failed, to rerun pass `-p gc --test track_caller`       
```