### PR TITLE
Fix non-local impl warning

### DIFF
--- a/gc_derive/Cargo.toml
+++ b/gc_derive/Cargo.toml
@@ -18,4 +18,4 @@ proc-macro = true
 syn = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-synstructure = "0.12"
+synstructure = "0.13"

--- a/gc_derive/src/lib.rs
+++ b/gc_derive/src/lib.rs
@@ -8,7 +8,7 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
         !bi.ast()
             .attrs
             .iter()
-            .any(|attr| attr.path.is_ident("unsafe_ignore_trace"))
+            .any(|attr| attr.path().is_ident("unsafe_ignore_trace"))
     });
     let trace_body = s.each(|bi| quote!(mark(#bi)));
 


### PR DESCRIPTION
Updating synstructure seems to fix this warning by not giving the global throwaway constants unique names.

Fixes #174.