### PR TITLE
Fix clippy::thread_local_initializer_can_be_made_const

### DIFF
--- a/gc/src/gc.rs
+++ b/gc/src/gc.rs
@@ -26,7 +26,7 @@ impl Drop for GcState {
 
 // Whether or not the thread is currently in the sweep phase of garbage collection.
 // During this phase, attempts to dereference a `Gc<T>` pointer will trigger a panic.
-thread_local!(pub static GC_DROPPING: Cell<bool> = Cell::new(false));
+thread_local!(pub static GC_DROPPING: Cell<bool> = const { Cell::new(false) });
 struct DropGuard;
 impl DropGuard {
     fn new() -> DropGuard {


### PR DESCRIPTION
```
warning: initializer for `thread_local` value can be made `const`
  --> gc/src/gc.rs:29:52
   |
29 | thread_local!(pub static GC_DROPPING: Cell<bool> = Cell::new(false));
   |                                                    ^^^^^^^^^^^^^^^^ help: replace with: `const { Cell::new(false) }`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#thread_local_initializer_can_be_made_const
   = note: `#[warn(clippy::thread_local_initializer_can_be_made_const)]` on by default
```