### PR TITLE
Remove finalizer method bodies and bounds from implementations for standard library types

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ impl Finalize for Foo {
         // Clean up resources for Foo, because we think it will be destroyed.
         // Foo may not be destroyed after a call to finalize, as another
         // finalizer may create a reference to it due to reference cycles.
+        // Recursive calls of Finalize::finalize on fields are not required here
+        // because this is handled by Trace::finalize_glue already.
     }
 }
 ```

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -172,13 +172,7 @@ simple_empty_finalize_trace![
     RandomState
 ];
 
-impl<T: Finalize, const N: usize> Finalize for [T; N] {
-    fn finalize(&self) {
-        for v in self {
-            v.finalize();
-        }
-    }
-}
+impl<T, const N: usize> Finalize for [T; N] {}
 unsafe impl<T: Trace, const N: usize> Trace for [T; N] {
     custom_trace!(this, {
         for v in this {
@@ -213,13 +207,7 @@ macro_rules! fn_finalize_trace_group {
 macro_rules! tuple_finalize_trace {
     () => {}; // This case is handled above, by simple_finalize_empty_trace!().
     ($($args:ident),*) => {
-        impl<$($args: $crate::Finalize),*> Finalize for ($($args,)*) {
-            fn finalize(&self) {
-                #[allow(non_snake_case)]
-                let &($(ref $args,)*) = self;
-                $(($args).finalize();)*
-            }
-        }
+        impl<$($args),*> Finalize for ($($args,)*) {}
         unsafe impl<$($args: $crate::Trace),*> Trace for ($($args,)*) {
             custom_trace!(this, {
                 #[allow(non_snake_case)]
@@ -255,24 +243,14 @@ type_arg_tuple_based_finalize_trace_impls![
     (A, B, C, D, E, F, G, H, I, J, K, L);
 ];
 
-impl<T: Finalize + ?Sized> Finalize for Box<T> {
-    fn finalize(&self) {
-        (**self).finalize();
-    }
-}
+impl<T: ?Sized> Finalize for Box<T> {}
 unsafe impl<T: Trace + ?Sized> Trace for Box<T> {
     custom_trace!(this, {
         mark(&**this);
     });
 }
 
-impl<T: Finalize> Finalize for [T] {
-    fn finalize(&self) {
-        for e in self {
-            e.finalize();
-        }
-    }
-}
+impl<T> Finalize for [T] {}
 unsafe impl<T: Trace> Trace for [T] {
     custom_trace!(this, {
         for e in this {
@@ -281,13 +259,7 @@ unsafe impl<T: Trace> Trace for [T] {
     });
 }
 
-impl<T: Finalize> Finalize for Vec<T> {
-    fn finalize(&self) {
-        for e in self {
-            e.finalize();
-        }
-    }
-}
+impl<T> Finalize for Vec<T> {}
 unsafe impl<T: Trace> Trace for Vec<T> {
     custom_trace!(this, {
         for e in this {
@@ -296,13 +268,7 @@ unsafe impl<T: Trace> Trace for Vec<T> {
     });
 }
 
-impl<T: Finalize> Finalize for Option<T> {
-    fn finalize(&self) {
-        if let Some(v) = self {
-            v.finalize();
-        }
-    }
-}
+impl<T> Finalize for Option<T> {}
 unsafe impl<T: Trace> Trace for Option<T> {
     custom_trace!(this, {
         if let Some(v) = this {
@@ -311,14 +277,7 @@ unsafe impl<T: Trace> Trace for Option<T> {
     });
 }
 
-impl<T: Finalize, E: Finalize> Finalize for Result<T, E> {
-    fn finalize(&self) {
-        match self {
-            Ok(v) => v.finalize(),
-            Err(v) => v.finalize(),
-        }
-    }
-}
+impl<T, E> Finalize for Result<T, E> {}
 unsafe impl<T: Trace, E: Trace> Trace for Result<T, E> {
     custom_trace!(this, {
         match this {
@@ -328,13 +287,7 @@ unsafe impl<T: Trace, E: Trace> Trace for Result<T, E> {
     });
 }
 
-impl<T: Finalize> Finalize for BinaryHeap<T> {
-    fn finalize(&self) {
-        for v in self {
-            v.finalize();
-        }
-    }
-}
+impl<T> Finalize for BinaryHeap<T> {}
 unsafe impl<T: Trace> Trace for BinaryHeap<T> {
     custom_trace!(this, {
         for v in this {
@@ -343,14 +296,7 @@ unsafe impl<T: Trace> Trace for BinaryHeap<T> {
     });
 }
 
-impl<K: Finalize, V: Finalize> Finalize for BTreeMap<K, V> {
-    fn finalize(&self) {
-        for (k, v) in self {
-            k.finalize();
-            v.finalize();
-        }
-    }
-}
+impl<K, V> Finalize for BTreeMap<K, V> {}
 unsafe impl<K: Trace, V: Trace> Trace for BTreeMap<K, V> {
     custom_trace!(this, {
         for (k, v) in this {
@@ -360,13 +306,7 @@ unsafe impl<K: Trace, V: Trace> Trace for BTreeMap<K, V> {
     });
 }
 
-impl<T: Finalize> Finalize for BTreeSet<T> {
-    fn finalize(&self) {
-        for v in self {
-            v.finalize();
-        }
-    }
-}
+impl<T> Finalize for BTreeSet<T> {}
 unsafe impl<T: Trace> Trace for BTreeSet<T> {
     custom_trace!(this, {
         for v in this {
@@ -375,15 +315,7 @@ unsafe impl<T: Trace> Trace for BTreeSet<T> {
     });
 }
 
-impl<K: Finalize, V: Finalize, S: Finalize> Finalize for HashMap<K, V, S> {
-    fn finalize(&self) {
-        self.hasher().finalize();
-        for (k, v) in self {
-            k.finalize();
-            v.finalize();
-        }
-    }
-}
+impl<K, V, S> Finalize for HashMap<K, V, S> {}
 unsafe impl<K: Trace, V: Trace, S: Trace> Trace for HashMap<K, V, S> {
     custom_trace!(this, {
         mark(this.hasher());
@@ -394,14 +326,7 @@ unsafe impl<K: Trace, V: Trace, S: Trace> Trace for HashMap<K, V, S> {
     });
 }
 
-impl<T: Finalize, S: Finalize> Finalize for HashSet<T, S> {
-    fn finalize(&self) {
-        self.hasher().finalize();
-        for v in self {
-            v.finalize();
-        }
-    }
-}
+impl<T, S> Finalize for HashSet<T, S> {}
 unsafe impl<T: Trace, S: Trace> Trace for HashSet<T, S> {
     custom_trace!(this, {
         mark(this.hasher());
@@ -411,13 +336,7 @@ unsafe impl<T: Trace, S: Trace> Trace for HashSet<T, S> {
     });
 }
 
-impl<T: Finalize> Finalize for LinkedList<T> {
-    fn finalize(&self) {
-        for v in self {
-            v.finalize();
-        }
-    }
-}
+impl<T> Finalize for LinkedList<T> {}
 unsafe impl<T: Trace> Trace for LinkedList<T> {
     custom_trace!(this, {
         for v in this.iter() {
@@ -431,13 +350,7 @@ unsafe impl<T: ?Sized> Trace for PhantomData<T> {
     unsafe_empty_trace!();
 }
 
-impl<T: Finalize> Finalize for VecDeque<T> {
-    fn finalize(&self) {
-        for v in self {
-            v.finalize();
-        }
-    }
-}
+impl<T> Finalize for VecDeque<T> {}
 unsafe impl<T: Trace> Trace for VecDeque<T> {
     custom_trace!(this, {
         for v in this {
@@ -446,16 +359,7 @@ unsafe impl<T: Trace> Trace for VecDeque<T> {
     });
 }
 
-impl<'a, T: ToOwned + ?Sized> Finalize for Cow<'a, T>
-where
-    T::Owned: Finalize,
-{
-    fn finalize(&self) {
-        if let Cow::Owned(ref v) = self {
-            v.finalize();
-        }
-    }
-}
+impl<'a, T: ToOwned + ?Sized> Finalize for Cow<'a, T>{}
 unsafe impl<'a, T: ToOwned + ?Sized> Trace for Cow<'a, T>
 where
     T::Owned: Trace,


### PR DESCRIPTION
These are already handled by `Trace::finalize_glue`; fixes #182

The macro `#[derive(Finalize)]` was already correctly generating empty `Finalize` implementations.