### PR TITLE
Robust behavior when finalizers ressurect GC data (fixes #124)

### DIFF
--- a/gc/tests/finalize.rs
+++ b/gc/tests/finalize.rs
@@ -1,4 +1,4 @@
-use gc::{Finalize, Trace};
+use gc::{Finalize, Gc, GcCell, Trace};
 use std::cell::Cell;
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
@@ -45,4 +45,32 @@ fn drop_triggers_finalize() {
         FLAGS.with(|f| assert_eq!(f.get(), Flags(0, 0)));
     }
     FLAGS.with(|f| assert_eq!(f.get(), Flags(1, 1)));
+}
+
+#[derive(Trace)]
+struct Ressurection {
+    escape: Gc<GcCell<Gc<String>>>,
+    value: Gc<String>,
+}
+
+impl Finalize for Ressurection {
+    fn finalize(&self) {
+        *self.escape.borrow_mut() = self.value.clone();
+    }
+}
+
+// run this with miri to detect UB
+// cargo +nightly miri test -p gc --test finalize
+#[test]
+fn finalizer_can_ressurect() {
+    let escape = Gc::new(GcCell::new(Gc::new(String::new())));
+    let value = Gc::new(GcCell::new(Ressurection {
+        escape: escape.clone(),
+        value: Gc::new(String::from("Hello world")),
+    }));
+    drop(value);
+
+    gc::force_collect();
+
+    assert_eq!(&**escape.borrow(), "Hello world");
 }


### PR DESCRIPTION
- Types with non-trivial finalizers take two garbage collection cycles to reclaim.
- Finalizers are only run once even when the data is ressurected.

This is implemented through using a persistent bit that is set when a node's finalizer is run, and by running sweep() only on finalized nodes.

More details to follow as the implementation progresses.