### PR TITLE
Add `#[empty_trace]` attribute for `Trace` derive macro

### DIFF
--- a/gc/src/empty_trace.rs
+++ b/gc/src/empty_trace.rs
@@ -1,0 +1,9 @@
+use std::rc::Rc;
+
+/// A marker trait for types that don't require tracing.
+/// TODO: Safety conditions
+pub unsafe trait EmptyTrace {}
+
+unsafe impl EmptyTrace for String {}
+
+unsafe impl<T: EmptyTrace> EmptyTrace for Rc<T> {}

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -30,14 +30,16 @@ mod gc;
 #[cfg(feature = "serde")]
 mod serde;
 mod trace;
+mod empty_trace;
 
 #[cfg(feature = "derive")]
-pub use gc_derive::{Finalize, Trace};
+pub use gc_derive::{Finalize, Trace, EmptyTrace};
 
 // We re-export the Trace method, as well as some useful internal methods for
 // managing collections or configuring the garbage collector.
 pub use crate::gc::{finalizer_safe, force_collect};
 pub use crate::trace::{Finalize, Trace};
+pub use crate::empty_trace::EmptyTrace;
 
 #[cfg(feature = "unstable-config")]
 pub use crate::gc::{configure, GcConfig};

--- a/gc/tests/empty_trace.rs
+++ b/gc/tests/empty_trace.rs
@@ -1,0 +1,26 @@
+#[allow(dead_code)]
+mod static_tests {
+    use gc::Gc;
+    use gc_derive::{EmptyTrace, Finalize, Trace};
+    use std::rc::Rc;
+    
+    #[derive(EmptyTrace)]
+    struct StructWithEmptyTrace(Rc<String>);
+
+    #[derive(Trace, Finalize)]
+    struct Traceable<T> {
+        #[empty_trace]
+        a: StructWithEmptyTrace,
+
+        #[empty_trace]
+        b: T,
+    }
+
+    fn test_empty_trace() {
+        let x = Rc::new(String::new());
+        Gc::new(Traceable {
+            a: StructWithEmptyTrace(x.clone()),
+            b: x.clone(),
+        });
+    }
+}

--- a/gc_derive/Cargo.toml
+++ b/gc_derive/Cargo.toml
@@ -18,3 +18,4 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 synstructure = "0.13"
+syn = "2.0.95"

--- a/gc_derive/src/lib.rs
+++ b/gc_derive/src/lib.rs
@@ -1,7 +1,9 @@
 use quote::quote;
+use syn::parse_quote_spanned;
+use syn::spanned::Spanned;
 use synstructure::{decl_derive, AddBounds, Structure};
 
-decl_derive!([Trace, attributes(unsafe_ignore_trace)] => derive_trace);
+decl_derive!([Trace, attributes(unsafe_ignore_trace, empty_trace)] => derive_trace);
 
 fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
     s.filter(|bi| {
@@ -10,6 +12,37 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
             .iter()
             .any(|attr| attr.path().is_ident("unsafe_ignore_trace"))
     });
+
+    // We also implement drop to prevent unsafe drop implementations on this
+    // type and encourage people to use Finalize. This implementation will
+    // call `Finalize::finalize` if it is safe to do so.
+    let drop_impl = s.unbound_impl(
+        quote!(::std::ops::Drop),
+        quote! {
+            fn drop(&mut self) {
+                if ::gc::finalizer_safe() {
+                    ::gc::Finalize::finalize(self);
+                }
+            }
+        },
+    );
+
+    // Separate all the bindings that were annotated with `#[empty_trace]`
+    let empty_trace_bindings = s.drain_filter(|bi| {
+        bi.ast()
+            .attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("empty_trace"))
+    });
+
+    // Require the annotated bindings to implement `EmptyTrace`
+    for variant in empty_trace_bindings.variants() {
+        for binding in variant.bindings() {
+            let ty = &binding.ast().ty;
+            s.add_where_predicate(parse_quote_spanned!(ty.span()=> #ty: ::gc::EmptyTrace));
+        }
+    }
+
     let trace_body = s.each(|bi| quote!(mark(#bi)));
 
     s.add_bounds(AddBounds::Fields);
@@ -52,20 +85,6 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
         },
     );
 
-    // We also implement drop to prevent unsafe drop implementations on this
-    // type and encourage people to use Finalize. This implementation will
-    // call `Finalize::finalize` if it is safe to do so.
-    let drop_impl = s.unbound_impl(
-        quote!(::std::ops::Drop),
-        quote! {
-            fn drop(&mut self) {
-                if ::gc::finalizer_safe() {
-                    ::gc::Finalize::finalize(self);
-                }
-            }
-        },
-    );
-
     quote! {
         #trace_impl
         #drop_impl
@@ -77,4 +96,24 @@ decl_derive!([Finalize] => derive_finalize);
 #[allow(clippy::needless_pass_by_value)]
 fn derive_finalize(s: Structure<'_>) -> proc_macro2::TokenStream {
     s.unbound_impl(quote!(::gc::Finalize), quote!())
+}
+
+decl_derive!([EmptyTrace] => derive_empty_trace);
+
+// TODO: Does not work on self-referential types
+fn derive_empty_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
+    // Add where bounds for all bindings manually because synstructure only adds them if they depend on one of the parameters.
+    let mut where_predicates = Vec::new();
+    for v in s.variants() {
+        for bi in v.bindings() {
+            let ty = &bi.ast().ty;
+            let span = ty.span();
+            where_predicates.push(parse_quote_spanned! { span=> #ty: ::gc::EmptyTrace });
+        }
+    }
+    for p in where_predicates {
+        s.add_where_predicate(p);
+    }
+    s.add_bounds(AddBounds::None);
+    s.unsafe_bound_impl(quote! { ::gc::EmptyTrace }, quote! {})
 }


### PR DESCRIPTION
As suggested in issue #109, I have added a marker trait, `EmptyTrace`, for types that don't require tracing, a derive macro for this trait and an attribute ,`#[empty_trace]`, for the `Trace` derive macro that allows users to safely skip fields which implement `EmptyTrace`. All of this is demonstrated in [gc/tests/empty_trace.rs](https://github.com/s9ferech/rust-gc/blob/fefec659f8093d6dfeade85c466989d5124ad228/gc/tests/empty_trace.rs). I believe that something like this would be very nice to have, especially since the `Trace` implementation for `Rc` does not exist anymore.

Would this implementation be safe? I am not familiar with the exact safety assumptions that the library makes about `Trace` implementations. Or would there be any other issues with this approach?