### PR TITLE
Fix warnings when using `custom_trace` macro from Rust 2024 Edition

### DIFF
--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -100,6 +100,7 @@ macro_rules! custom_trace {
             }
             $crate::Finalize::finalize(self);
             let $this = self;
+            #[allow(unused_unsafe)]
             $body
         }
     };


### PR DESCRIPTION
When using `custom_trace!` in the Rust 2024 Edition, calling `mark` directly can trigger an `unsafe_op_in_unsafe_fn` warning. However, wrapping `mark` in an `unsafe` block causes an `unused_unsafe` warning instead. This PR modifies the macro so that no warnings are emitted when `mark` is called inside an `unsafe` block.


```rust
#[derive(gc_derive::Finalize)]
pub struct Foo;

unsafe impl gc::Trace for Foo {
    gc::custom_trace!(this, {
        // warning[E0133]: call to unsafe function `<runtime::Foo as gc::Trace>::unroot::mark` is unsafe and requires unsafe block
        mark(this);
    });
}
```

```rust
#[derive(gc_derive::Finalize)]
pub struct Foo;

unsafe impl gc::Trace for Foo {
    gc::custom_trace!(this,  {
        // warning: unnecessary `unsafe` block
        unsafe { mark(this); }
    });
}
```