### PR TITLE
Fix auto-fixable pedantic Clippy warnings

### DIFF
--- a/gc/src/gc.rs
+++ b/gc/src/gc.rs
@@ -222,7 +222,7 @@ impl<T: ?Sized> GcBox<T> {
     pub(crate) fn ptr_eq(this: &GcBox<T>, other: &GcBox<T>) -> bool {
         // Use .header to ignore fat pointer vtables, to work around
         // https://github.com/rust-lang/rust/issues/46139
-        ptr::eq(&this.header, &other.header)
+        ptr::eq(&raw const this.header, &raw const other.header)
     }
 }
 

--- a/gc/src/lib.rs
+++ b/gc/src/lib.rs
@@ -868,7 +868,7 @@ impl<'a, T: ?Sized> GcCellRef<'a, T> {
     }
 }
 
-impl<'a, T: ?Sized> Deref for GcCellRef<'a, T> {
+impl<T: ?Sized> Deref for GcCellRef<'_, T> {
     type Target = T;
 
     #[inline]
@@ -877,20 +877,20 @@ impl<'a, T: ?Sized> Deref for GcCellRef<'a, T> {
     }
 }
 
-impl<'a, T: ?Sized> Drop for GcCellRef<'a, T> {
+impl<T: ?Sized> Drop for GcCellRef<'_, T> {
     fn drop(&mut self) {
         debug_assert!(self.flags.get().borrowed() == BorrowState::Reading);
         self.flags.set(self.flags.get().sub_reading());
     }
 }
 
-impl<'a, T: ?Sized + Debug> Debug for GcCellRef<'a, T> {
+impl<T: ?Sized + Debug> Debug for GcCellRef<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Debug::fmt(&**self, f)
     }
 }
 
-impl<'a, T: ?Sized + Display> Display for GcCellRef<'a, T> {
+impl<T: ?Sized + Display> Display for GcCellRef<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&**self, f)
     }
@@ -997,7 +997,7 @@ impl<'a, T: Trace + ?Sized, U: ?Sized> GcCellRefMut<'a, T, U> {
     }
 }
 
-impl<'a, T: Trace + ?Sized, U: ?Sized> Deref for GcCellRefMut<'a, T, U> {
+impl<T: Trace + ?Sized, U: ?Sized> Deref for GcCellRefMut<'_, T, U> {
     type Target = U;
 
     #[inline]
@@ -1006,14 +1006,14 @@ impl<'a, T: Trace + ?Sized, U: ?Sized> Deref for GcCellRefMut<'a, T, U> {
     }
 }
 
-impl<'a, T: Trace + ?Sized, U: ?Sized> DerefMut for GcCellRefMut<'a, T, U> {
+impl<T: Trace + ?Sized, U: ?Sized> DerefMut for GcCellRefMut<'_, T, U> {
     #[inline]
     fn deref_mut(&mut self) -> &mut U {
         self.value
     }
 }
 
-impl<'a, T: Trace + ?Sized, U: ?Sized> Drop for GcCellRefMut<'a, T, U> {
+impl<T: Trace + ?Sized, U: ?Sized> Drop for GcCellRefMut<'_, T, U> {
     #[inline]
     fn drop(&mut self) {
         debug_assert!(self.gc_cell.flags.get().borrowed() == BorrowState::Writing);
@@ -1030,13 +1030,13 @@ impl<'a, T: Trace + ?Sized, U: ?Sized> Drop for GcCellRefMut<'a, T, U> {
     }
 }
 
-impl<'a, T: Trace + ?Sized, U: Debug + ?Sized> Debug for GcCellRefMut<'a, T, U> {
+impl<T: Trace + ?Sized, U: Debug + ?Sized> Debug for GcCellRefMut<'_, T, U> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Debug::fmt(&**self, f)
     }
 }
 
-impl<'a, T: Trace + ?Sized, U: Display + ?Sized> Display for GcCellRefMut<'a, T, U> {
+impl<T: Trace + ?Sized, U: Display + ?Sized> Display for GcCellRefMut<'_, T, U> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&**self, f)
     }

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -340,7 +340,7 @@ unsafe impl<T: Trace, S: Trace> Trace for HashSet<T, S> {
 impl<T> Finalize for LinkedList<T> {}
 unsafe impl<T: Trace> Trace for LinkedList<T> {
     custom_trace!(this, {
-        for v in this.iter() {
+        for v in this {
             mark(v);
         }
     });

--- a/gc/src/trace.rs
+++ b/gc/src/trace.rs
@@ -360,8 +360,8 @@ unsafe impl<T: Trace> Trace for VecDeque<T> {
     });
 }
 
-impl<'a, T: ToOwned + ?Sized> Finalize for Cow<'a, T>{}
-unsafe impl<'a, T: ToOwned + ?Sized> Trace for Cow<'a, T>
+impl<T: ToOwned + ?Sized> Finalize for Cow<'_, T> {}
+unsafe impl<T: ToOwned + ?Sized> Trace for Cow<'_, T>
 where
     T::Owned: Trace,
 {


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#borrow_as_ptr
https://rust-lang.github.io/rust-clippy/master/index.html#elidable_lifetime_names
https://rust-lang.github.io/rust-clippy/master/index.html#explicit_iter_loop

Note that `&raw` requires Rust ≥ 1.82.